### PR TITLE
Add missing curl and check HTTP status code in 2xx range

### DIFF
--- a/Dockerfiles/admin/Dockerfile
+++ b/Dockerfiles/admin/Dockerfile
@@ -60,7 +60,7 @@ RUN { \
   #   - Tesseract Open Source OCR Engine
   #   - Hunspell
  && apk add --no-cache --virtual .run-deps \
-      su-exec openssl tzdata \
+      su-exec openssl tzdata curl \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
       ffmpeg \
       sox \

--- a/Dockerfiles/admin/assets/docker-healthcheck.sh
+++ b/Dockerfiles/admin/assets/docker-healthcheck.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 OPENCAST_API="http://127.0.0.1:8080"
-DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' etc/custom.properties | tr -d ' ')
-DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' etc/custom.properties | tr -d ' ')
+DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' "${OPENCAST_CONFIG}/etc/custom.properties" | tr -d ' ')
+DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' "${OPENCAST_CONFIG}/etc/custom.properties" | tr -d ' ')
 
 for ENDPOINT in "services/health" "broker/status"; do
   HTTP_CODE=$(curl \
@@ -30,7 +30,8 @@ for ENDPOINT in "services/health" "broker/status"; do
   )
 
   [           "$?" -eq   0 ] || exit 1
-  [ "${HTTP_CODE}" -eq 204 ] || exit 1
+  [ "${HTTP_CODE}" -ge 200 ] && \
+  [ "${HTTP_CODE}" -lt 300 ] || exit 1
 done
 
 exit 0

--- a/Dockerfiles/adminworker/Dockerfile
+++ b/Dockerfiles/adminworker/Dockerfile
@@ -60,7 +60,7 @@ RUN { \
   #   - Tesseract Open Source OCR Engine
   #   - Hunspell
  && apk add --no-cache --virtual .run-deps \
-      su-exec openssl tzdata \
+      su-exec openssl tzdata curl \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
       ffmpeg \
       sox \

--- a/Dockerfiles/adminworker/assets/docker-healthcheck.sh
+++ b/Dockerfiles/adminworker/assets/docker-healthcheck.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 OPENCAST_API="http://127.0.0.1:8080"
-DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' etc/custom.properties | tr -d ' ')
-DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' etc/custom.properties | tr -d ' ')
+DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' "${OPENCAST_CONFIG}/etc/custom.properties" | tr -d ' ')
+DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' "${OPENCAST_CONFIG}/etc/custom.properties" | tr -d ' ')
 
 for ENDPOINT in "services/health" "broker/status"; do
   HTTP_CODE=$(curl \
@@ -30,7 +30,8 @@ for ENDPOINT in "services/health" "broker/status"; do
   )
 
   [           "$?" -eq   0 ] || exit 1
-  [ "${HTTP_CODE}" -eq 204 ] || exit 1
+  [ "${HTTP_CODE}" -ge 200 ] && \
+  [ "${HTTP_CODE}" -lt 300 ] || exit 1
 done
 
 exit 0

--- a/Dockerfiles/allinone/Dockerfile
+++ b/Dockerfiles/allinone/Dockerfile
@@ -60,7 +60,7 @@ RUN { \
   #   - Tesseract Open Source OCR Engine
   #   - Hunspell
  && apk add --no-cache --virtual .run-deps \
-      su-exec openssl tzdata \
+      su-exec openssl tzdata curl \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
       ffmpeg \
       sox \

--- a/Dockerfiles/allinone/assets/docker-healthcheck.sh
+++ b/Dockerfiles/allinone/assets/docker-healthcheck.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 OPENCAST_API="http://127.0.0.1:8080"
-DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' etc/custom.properties | tr -d ' ')
-DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' etc/custom.properties | tr -d ' ')
+DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' "${OPENCAST_CONFIG}/etc/custom.properties" | tr -d ' ')
+DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' "${OPENCAST_CONFIG}/etc/custom.properties" | tr -d ' ')
 
 for ENDPOINT in "services/health" "broker/status"; do
   HTTP_CODE=$(curl \
@@ -30,7 +30,8 @@ for ENDPOINT in "services/health" "broker/status"; do
   )
 
   [           "$?" -eq   0 ] || exit 1
-  [ "${HTTP_CODE}" -eq 204 ] || exit 1
+  [ "${HTTP_CODE}" -ge 200 ] && \
+  [ "${HTTP_CODE}" -lt 300 ] || exit 1
 done
 
 exit 0

--- a/Dockerfiles/build/Dockerfile
+++ b/Dockerfiles/build/Dockerfile
@@ -53,18 +53,9 @@ RUN dnf -y install \
       java-1.8.0-openjdk maven \
       python nodejs \
   \
- # && npm install -g npm@2 \
- # \
- # && mkdir -p /tmp/phantomjs \
- # && cd /tmp/phantomjs \
- # && wget -O phantomjs.tar.bz2 "${PHANTOMJS_URL}" \
- # && echo "86dd9a4bf4aee45f1a84c9f61cf1947c1d6dce9b9e8d2a907105da7852460d2f  phantomjs.tar.bz2" | sha256sum -c - \
- # && tar -xjf phantomjs.tar.bz2 --strip 1 \
- # && cp bin/phantomjs /usr/local/bin/ \
-  \
   # Run deps
  && dnf -y install \
-      openssl tzdata \
+      openssl tzdata curl \
       fontconfig dejavu-sans-fonts dejavu-sans-mono-fonts dejavu-serif-fonts \
       gnu-free-serif-fonts gnu-free-mono-fonts gnu-free-sans-fonts \
       liberation-fonts linux-libertine-fonts \
@@ -77,6 +68,7 @@ RUN dnf -y install \
  && cd /tmp/su-exec \
  && make \
  && cp su-exec /usr/local/sbin \
+  \
   # Install languag files for tesseract and hunspell
  && mkdir -p /tmp/tesseract /tmp/hunspell /usr/share/tessdata /usr/share/hunspell \
  && { \

--- a/Dockerfiles/ingest/Dockerfile
+++ b/Dockerfiles/ingest/Dockerfile
@@ -60,7 +60,7 @@ RUN { \
   #   - Tesseract Open Source OCR Engine
   #   - Hunspell
  && apk add --no-cache --virtual .run-deps \
-      su-exec openssl tzdata \
+      su-exec openssl tzdata curl \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
       ffmpeg \
       sox \

--- a/Dockerfiles/ingest/assets/docker-healthcheck.sh
+++ b/Dockerfiles/ingest/assets/docker-healthcheck.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 OPENCAST_API="http://127.0.0.1:8080"
-DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' etc/custom.properties | tr -d ' ')
-DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' etc/custom.properties | tr -d ' ')
+DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' "${OPENCAST_CONFIG}/etc/custom.properties" | tr -d ' ')
+DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' "${OPENCAST_CONFIG}/etc/custom.properties" | tr -d ' ')
 
 for ENDPOINT in "services/health" "broker/status"; do
   HTTP_CODE=$(curl \
@@ -30,7 +30,8 @@ for ENDPOINT in "services/health" "broker/status"; do
   )
 
   [           "$?" -eq   0 ] || exit 1
-  [ "${HTTP_CODE}" -eq 204 ] || exit 1
+  [ "${HTTP_CODE}" -ge 200 ] && \
+  [ "${HTTP_CODE}" -lt 300 ] || exit 1
 done
 
 exit 0

--- a/Dockerfiles/presentation/Dockerfile
+++ b/Dockerfiles/presentation/Dockerfile
@@ -60,7 +60,7 @@ RUN { \
   #   - Tesseract Open Source OCR Engine
   #   - Hunspell
  && apk add --no-cache --virtual .run-deps \
-      su-exec openssl tzdata \
+      su-exec openssl tzdata curl \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
       ffmpeg \
       sox \

--- a/Dockerfiles/presentation/assets/docker-healthcheck.sh
+++ b/Dockerfiles/presentation/assets/docker-healthcheck.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 OPENCAST_API="http://127.0.0.1:8080"
-DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' etc/custom.properties | tr -d ' ')
-DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' etc/custom.properties | tr -d ' ')
+DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' "${OPENCAST_CONFIG}/etc/custom.properties" | tr -d ' ')
+DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' "${OPENCAST_CONFIG}/etc/custom.properties" | tr -d ' ')
 
 for ENDPOINT in "services/health" "broker/status"; do
   HTTP_CODE=$(curl \
@@ -30,7 +30,8 @@ for ENDPOINT in "services/health" "broker/status"; do
   )
 
   [           "$?" -eq   0 ] || exit 1
-  [ "${HTTP_CODE}" -eq 204 ] || exit 1
+  [ "${HTTP_CODE}" -ge 200 ] && \
+  [ "${HTTP_CODE}" -lt 300 ] || exit 1
 done
 
 exit 0

--- a/Dockerfiles/worker/Dockerfile
+++ b/Dockerfiles/worker/Dockerfile
@@ -60,7 +60,7 @@ RUN { \
   #   - Tesseract Open Source OCR Engine
   #   - Hunspell
  && apk add --no-cache --virtual .run-deps \
-      su-exec openssl tzdata \
+      su-exec openssl tzdata curl \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
       ffmpeg \
       sox \

--- a/Dockerfiles/worker/assets/docker-healthcheck.sh
+++ b/Dockerfiles/worker/assets/docker-healthcheck.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 OPENCAST_API="http://127.0.0.1:8080"
-DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' etc/custom.properties | tr -d ' ')
-DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' etc/custom.properties | tr -d ' ')
+DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' "${OPENCAST_CONFIG}/etc/custom.properties" | tr -d ' ')
+DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' "${OPENCAST_CONFIG}/etc/custom.properties" | tr -d ' ')
 
 for ENDPOINT in "services/health" "broker/status"; do
   HTTP_CODE=$(curl \
@@ -30,7 +30,8 @@ for ENDPOINT in "services/health" "broker/status"; do
   )
 
   [           "$?" -eq   0 ] || exit 1
-  [ "${HTTP_CODE}" -eq 204 ] || exit 1
+  [ "${HTTP_CODE}" -ge 200 ] && \
+  [ "${HTTP_CODE}" -lt 300 ] || exit 1
 done
 
 exit 0


### PR DESCRIPTION
The HEALTHCHECK could not run before as the `curl` command was missing. Also the HTTP status check now not only looks for `204` but for any `2xx`.