### PR TITLE
Fix various build script errors

### DIFF
--- a/Dockerfiles/build/assets/bin/is_git_repo
+++ b/Dockerfiles/build/assets/bin/is_git_repo
@@ -14,6 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-
 test -d ".git"

--- a/Dockerfiles/build/assets/bin/is_oc_dist
+++ b/Dockerfiles/build/assets/bin/is_oc_dist
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-
 for dist in \
     "allinone" \
     "admin" \
@@ -25,6 +23,7 @@ for dist in \
     "presentation" \
     "worker" \
     ; do
-  test "$1" = "$dist" && return 0
+  test "$1" = "$dist" && exit 0
 done
-return 1
+
+exit 1

--- a/Dockerfiles/build/assets/bin/is_oc_installed
+++ b/Dockerfiles/build/assets/bin/is_oc_installed
@@ -14,6 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-
 test -n "$(ls -A "${OPENCAST_HOME}")"

--- a/Dockerfiles/build/assets/bin/oc_clean_data
+++ b/Dockerfiles/build/assets/bin/oc_clean_data
@@ -18,6 +18,8 @@ set -e
 
 log "oc_clean_data" "Start cleaning data"
 
-rm -rf "${OPENCAST_DATA:?}/*" "${OPENCAST_DATA:?}/.*"
+rm -rf "${OPENCAST_DATA}"
+mkdir -p "${OPENCAST_DATA}"
+chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_DATA}"
 
 log "oc_clean_data" "End cleaning data"

--- a/Dockerfiles/build/assets/bin/oc_clean_data
+++ b/Dockerfiles/build/assets/bin/oc_clean_data
@@ -18,8 +18,6 @@ set -e
 
 log "oc_clean_data" "Start cleaning data"
 
-rm -rf "${OPENCAST_DATA}"
-mkdir -p "${OPENCAST_DATA}"
-chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_DATA}"
+find "${OPENCAST_DATA:?}" -mindepth 1 -delete
 
 log "oc_clean_data" "End cleaning data"

--- a/Dockerfiles/build/assets/bin/oc_install
+++ b/Dockerfiles/build/assets/bin/oc_install
@@ -37,13 +37,16 @@ cd "${OPENCAST_SRC}"
 log "oc_install" "Extract archive"
 tar -xzf build/opencast-dist-$1-*.tar.gz --strip 1 -C "${OPENCAST_HOME}"
 
+log "oc_install" "Create folders"
+mkdir -p "${OPENCAST_CONFIG}" "${OPENCAST_SCRIPTS}" "${OPENCAST_SUPPORT}"
+
 log "oc_install" "Copy Docker scripts"
-cp -r ${OPENCAST_BUILD_ASSETS}/scripts "${OPENCAST_SCRIPTS}"
+cp -r ${OPENCAST_BUILD_ASSETS}/scripts/* "${OPENCAST_SCRIPTS}/"
 cp "${OPENCAST_BUILD_ASSETS}/docker-entrypoint.sh" "${OPENCAST_SCRIPTS}/docker-entrypoint.sh"
 javac "${OPENCAST_SCRIPTS}/TryToConnectToDb.java"
 
 log "oc_install" "Copy support files"
-cp -r ${OPENCAST_BUILD_ASSETS}/support "${OPENCAST_SUPPORT}"
+cp -r ${OPENCAST_BUILD_ASSETS}/support/* "${OPENCAST_SUPPORT}/"
 
 log "oc_install" "Copy configuration"
 cp -r ${OPENCAST_BUILD_ASSETS}/etc/$1/* "${OPENCAST_CONFIG}/"

--- a/Dockerfiles/build/assets/bin/oc_uninstall
+++ b/Dockerfiles/build/assets/bin/oc_uninstall
@@ -18,8 +18,6 @@ set -e
 
 log "oc_uninstall" "Start uninstallation"
 
-rm -rf "${OPENCAST_HOME}"
-mkdir -p "${OPENCAST_HOME}"
-chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_HOME}"
+find "${OPENCAST_HOME:?}" -mindepth 1 -delete
 
 log "oc_uninstall" "End uninstallation"

--- a/Dockerfiles/build/assets/bin/oc_uninstall
+++ b/Dockerfiles/build/assets/bin/oc_uninstall
@@ -16,8 +16,10 @@
 
 set -e
 
-log "oc_install" "Start uninstallation"
+log "oc_uninstall" "Start uninstallation"
 
-rm -rf "${OPENCAST_HOME:?}/*" "${OPENCAST_HOME:?}/.*"
+rm -rf "${OPENCAST_HOME}"
+mkdir -p "${OPENCAST_HOME}"
+chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_HOME}"
 
-log "oc_install" "End uninstallation"
+log "oc_uninstall" "End uninstallation"


### PR DESCRIPTION
This fixes various small errors in scripts of the build image:

* remove `set -e` were a failure should not stop the script
* replace falsely used `return` with `exit`
* cleaning of directories has not matched any file before (nothing was removed)
* during install some folders were not yet created

To verify run these commands from the root of this repository:

```sh
$ make build-build

$ export OPENCAST_SRC=$(mktemp -d)
$ docker-compose -p opencast-build -f docker-compose/docker-compose.build.yml up -d
$ docker-compose -p opencast-build -f docker-compose/docker-compose.build.yml exec opencast bash

$ oc_clone
# This should clone the Opencast repo and check out 2.3.0
$ oc_build
# This should build Opencast
$ oc_install allinone
# This should install the allinone distribution; it is extracted into /opencast
$ oc_run
# This should start Opencast; exit with ctrl+c
$ oc_uninstall
# This should uninstall Opencast, i.e. the directory /opencast is empty
$ oc_clean_data
# This should remove user data, i.e. the directory /data is empty
$ exit

$ docker-compose -p opencast-build -f docker-compose/docker-compose.build.yml down -v
$ sudo rm -rf $OPENCAST_SRC
```

The three `is_*` scripts are checked implicitly as they are called from other scripts.