### PR TITLE
Fix error in healthcheck script

### DIFF
--- a/Dockerfiles/admin/assets/docker-healthcheck.sh
+++ b/Dockerfiles/admin/assets/docker-healthcheck.sh
@@ -15,12 +15,13 @@
 # limitations under the License.
 
 OPENCAST_API="http://127.0.0.1:8080"
-DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' "${OPENCAST_CONFIG}/etc/custom.properties" | tr -d ' ')
-DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' "${OPENCAST_CONFIG}/etc/custom.properties" | tr -d ' ')
+DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' "${OPENCAST_CONFIG}/custom.properties" | tr -d ' ')
+DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' "${OPENCAST_CONFIG}/custom.properties" | tr -d ' ')
 
 for ENDPOINT in "services/health" "broker/status"; do
   HTTP_CODE=$(curl \
     -sw '%{http_code}' \
+    -o /dev/null \
     --digest \
     -u "${DIGEST_USER}:${DIGEST_PASSWORD}" \
     -H 'X-Requested-Auth: Digest' \
@@ -29,7 +30,7 @@ for ENDPOINT in "services/health" "broker/status"; do
     "${OPENCAST_API}/${ENDPOINT}" \
   )
 
-  [           "$?" -eq   0 ] || exit 1
+  [                     $? ] || exit 1
   [ "${HTTP_CODE}" -ge 200 ] && \
   [ "${HTTP_CODE}" -lt 300 ] || exit 1
 done

--- a/Dockerfiles/adminpresentation/assets/docker-healthcheck.sh
+++ b/Dockerfiles/adminpresentation/assets/docker-healthcheck.sh
@@ -15,12 +15,13 @@
 # limitations under the License.
 
 OPENCAST_API="http://127.0.0.1:8080"
-DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' etc/custom.properties | tr -d ' ')
-DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' etc/custom.properties | tr -d ' ')
+DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' "${OPENCAST_CONFIG}/custom.properties" | tr -d ' ')
+DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' "${OPENCAST_CONFIG}/custom.properties" | tr -d ' ')
 
 for ENDPOINT in "services/health" "broker/status"; do
   HTTP_CODE=$(curl \
     -sw '%{http_code}' \
+    -o /dev/null \
     --digest \
     -u "${DIGEST_USER}:${DIGEST_PASSWORD}" \
     -H 'X-Requested-Auth: Digest' \
@@ -29,8 +30,9 @@ for ENDPOINT in "services/health" "broker/status"; do
     "${OPENCAST_API}/${ENDPOINT}" \
   )
 
-  [           "$?" -eq   0 ] || exit 1
-  [ "${HTTP_CODE}" -eq 204 ] || exit 1
+  [                     $? ] || exit 1
+  [ "${HTTP_CODE}" -ge 200 ] && \
+  [ "${HTTP_CODE}" -lt 300 ] || exit 1
 done
 
 exit 0

--- a/Dockerfiles/adminworker/assets/docker-healthcheck.sh
+++ b/Dockerfiles/adminworker/assets/docker-healthcheck.sh
@@ -15,12 +15,13 @@
 # limitations under the License.
 
 OPENCAST_API="http://127.0.0.1:8080"
-DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' "${OPENCAST_CONFIG}/etc/custom.properties" | tr -d ' ')
-DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' "${OPENCAST_CONFIG}/etc/custom.properties" | tr -d ' ')
+DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' "${OPENCAST_CONFIG}/custom.properties" | tr -d ' ')
+DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' "${OPENCAST_CONFIG}/custom.properties" | tr -d ' ')
 
 for ENDPOINT in "services/health" "broker/status"; do
   HTTP_CODE=$(curl \
     -sw '%{http_code}' \
+    -o /dev/null \
     --digest \
     -u "${DIGEST_USER}:${DIGEST_PASSWORD}" \
     -H 'X-Requested-Auth: Digest' \
@@ -29,7 +30,7 @@ for ENDPOINT in "services/health" "broker/status"; do
     "${OPENCAST_API}/${ENDPOINT}" \
   )
 
-  [           "$?" -eq   0 ] || exit 1
+  [                     $? ] || exit 1
   [ "${HTTP_CODE}" -ge 200 ] && \
   [ "${HTTP_CODE}" -lt 300 ] || exit 1
 done

--- a/Dockerfiles/allinone/assets/docker-healthcheck.sh
+++ b/Dockerfiles/allinone/assets/docker-healthcheck.sh
@@ -15,12 +15,13 @@
 # limitations under the License.
 
 OPENCAST_API="http://127.0.0.1:8080"
-DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' "${OPENCAST_CONFIG}/etc/custom.properties" | tr -d ' ')
-DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' "${OPENCAST_CONFIG}/etc/custom.properties" | tr -d ' ')
+DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' "${OPENCAST_CONFIG}/custom.properties" | tr -d ' ')
+DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' "${OPENCAST_CONFIG}/custom.properties" | tr -d ' ')
 
 for ENDPOINT in "services/health" "broker/status"; do
   HTTP_CODE=$(curl \
     -sw '%{http_code}' \
+    -o /dev/null \
     --digest \
     -u "${DIGEST_USER}:${DIGEST_PASSWORD}" \
     -H 'X-Requested-Auth: Digest' \
@@ -29,7 +30,7 @@ for ENDPOINT in "services/health" "broker/status"; do
     "${OPENCAST_API}/${ENDPOINT}" \
   )
 
-  [           "$?" -eq   0 ] || exit 1
+  [                     $? ] || exit 1
   [ "${HTTP_CODE}" -ge 200 ] && \
   [ "${HTTP_CODE}" -lt 300 ] || exit 1
 done

--- a/Dockerfiles/ingest/assets/docker-healthcheck.sh
+++ b/Dockerfiles/ingest/assets/docker-healthcheck.sh
@@ -15,12 +15,13 @@
 # limitations under the License.
 
 OPENCAST_API="http://127.0.0.1:8080"
-DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' "${OPENCAST_CONFIG}/etc/custom.properties" | tr -d ' ')
-DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' "${OPENCAST_CONFIG}/etc/custom.properties" | tr -d ' ')
+DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' "${OPENCAST_CONFIG}/custom.properties" | tr -d ' ')
+DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' "${OPENCAST_CONFIG}/custom.properties" | tr -d ' ')
 
 for ENDPOINT in "services/health" "broker/status"; do
   HTTP_CODE=$(curl \
     -sw '%{http_code}' \
+    -o /dev/null \
     --digest \
     -u "${DIGEST_USER}:${DIGEST_PASSWORD}" \
     -H 'X-Requested-Auth: Digest' \
@@ -29,7 +30,7 @@ for ENDPOINT in "services/health" "broker/status"; do
     "${OPENCAST_API}/${ENDPOINT}" \
   )
 
-  [           "$?" -eq   0 ] || exit 1
+  [                     $? ] || exit 1
   [ "${HTTP_CODE}" -ge 200 ] && \
   [ "${HTTP_CODE}" -lt 300 ] || exit 1
 done

--- a/Dockerfiles/presentation/assets/docker-healthcheck.sh
+++ b/Dockerfiles/presentation/assets/docker-healthcheck.sh
@@ -15,12 +15,13 @@
 # limitations under the License.
 
 OPENCAST_API="http://127.0.0.1:8080"
-DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' "${OPENCAST_CONFIG}/etc/custom.properties" | tr -d ' ')
-DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' "${OPENCAST_CONFIG}/etc/custom.properties" | tr -d ' ')
+DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' "${OPENCAST_CONFIG}/custom.properties" | tr -d ' ')
+DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' "${OPENCAST_CONFIG}/custom.properties" | tr -d ' ')
 
 for ENDPOINT in "services/health" "broker/status"; do
   HTTP_CODE=$(curl \
     -sw '%{http_code}' \
+    -o /dev/null \
     --digest \
     -u "${DIGEST_USER}:${DIGEST_PASSWORD}" \
     -H 'X-Requested-Auth: Digest' \
@@ -29,7 +30,7 @@ for ENDPOINT in "services/health" "broker/status"; do
     "${OPENCAST_API}/${ENDPOINT}" \
   )
 
-  [           "$?" -eq   0 ] || exit 1
+  [                     $? ] || exit 1
   [ "${HTTP_CODE}" -ge 200 ] && \
   [ "${HTTP_CODE}" -lt 300 ] || exit 1
 done

--- a/Dockerfiles/worker/assets/docker-healthcheck.sh
+++ b/Dockerfiles/worker/assets/docker-healthcheck.sh
@@ -15,12 +15,13 @@
 # limitations under the License.
 
 OPENCAST_API="http://127.0.0.1:8080"
-DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' "${OPENCAST_CONFIG}/etc/custom.properties" | tr -d ' ')
-DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' "${OPENCAST_CONFIG}/etc/custom.properties" | tr -d ' ')
+DIGEST_USER=$(awk -F "=" '/org\.opencastproject\.security\.digest\.user/ {print $2}' "${OPENCAST_CONFIG}/custom.properties" | tr -d ' ')
+DIGEST_PASSWORD=$(awk -F "=" '/org\.opencastproject\.security\.digest\.pass/ {print $2}' "${OPENCAST_CONFIG}/custom.properties" | tr -d ' ')
 
 for ENDPOINT in "services/health" "broker/status"; do
   HTTP_CODE=$(curl \
     -sw '%{http_code}' \
+    -o /dev/null \
     --digest \
     -u "${DIGEST_USER}:${DIGEST_PASSWORD}" \
     -H 'X-Requested-Auth: Digest' \
@@ -29,7 +30,7 @@ for ENDPOINT in "services/health" "broker/status"; do
     "${OPENCAST_API}/${ENDPOINT}" \
   )
 
-  [           "$?" -eq   0 ] || exit 1
+  [                     $? ] || exit 1
   [ "${HTTP_CODE}" -ge 200 ] && \
   [ "${HTTP_CODE}" -lt 300 ] || exit 1
 done

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -39,6 +39,26 @@ load test_helper
   [ "${status}" -eq 0 ]
 }
 
+@test "all healthcheck scripts should be the same" {
+  run diff -q "${DOCKERFILES_ALLINONE}/assets/docker-healthcheck.sh" "${DOCKERFILES_ADMIN}/assets/docker-healthcheck.sh"
+  [ "${status}" -eq 0 ]
+
+  run diff -q "${DOCKERFILES_ALLINONE}/assets/docker-healthcheck.sh" "${DOCKERFILES_ADMINPRESENTATION}/assets/docker-healthcheck.sh"
+  [ "${status}" -eq 0 ]
+
+  run diff -q "${DOCKERFILES_ALLINONE}/assets/docker-healthcheck.sh" "${DOCKERFILES_ADMINWORKER}/assets/docker-healthcheck.sh"
+  [ "${status}" -eq 0 ]
+
+  run diff -q "${DOCKERFILES_ALLINONE}/assets/docker-healthcheck.sh" "${DOCKERFILES_INGEST}/assets/docker-healthcheck.sh"
+  [ "${status}" -eq 0 ]
+
+  run diff -q "${DOCKERFILES_ALLINONE}/assets/docker-healthcheck.sh" "${DOCKERFILES_PRESENTATION}/assets/docker-healthcheck.sh"
+  [ "${status}" -eq 0 ]
+
+  run diff -q "${DOCKERFILES_ALLINONE}/assets/docker-healthcheck.sh" "${DOCKERFILES_WORKER}/assets/docker-healthcheck.sh"
+  [ "${status}" -eq 0 ]
+}
+
 @test "all Dockerfiles should be the same" {
   allinone=$(grep -v 'OPENCAST_DISTRIBUTION="' "${DOCKERFILES_ALLINONE}/Dockerfile")
   admin=$(grep -v 'OPENCAST_DISTRIBUTION="' "${DOCKERFILES_ADMIN}/Dockerfile")


### PR DESCRIPTION
This fixes:

* wrong path
* shellcheck linting error with `$?` variable
* additional output is written to `/dev/null`
* differences between the distributions

in the `docker-healthcheck.sh` script.