### PR TITLE
Add gracefull stop handler

### DIFF
--- a/Dockerfiles/admin/Dockerfile
+++ b/Dockerfiles/admin/Dockerfile
@@ -61,7 +61,7 @@ RUN { \
   #   - Tesseract Open Source OCR Engine
   #   - Hunspell
  && apk add --no-cache --virtual .run-deps \
-      su-exec openssl tzdata curl \
+      bash su-exec openssl tzdata curl \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
       ffmpeg \
       sox \

--- a/Dockerfiles/admin/assets/docker-entrypoint.sh
+++ b/Dockerfiles/admin/assets/docker-entrypoint.sh
@@ -68,7 +68,27 @@ opencast_main_init() {
 
 opencast_main_start() {
   echo "Run opencast_main_start"
-  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast server
+
+  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast server &
+  OC_PID=$!
+  trap opencast_main_stop TERM INT
+
+  status=0
+
+  set +e
+  while kill -0 "$OC_PID" >/dev/null 2>&1; do
+    wait "$OC_PID"
+    status=$?
+  done
+  set -e
+
+  return $status
+}
+
+opencast_main_stop() {
+  echo "Run opencast_main_stop"
+
+  bin/stop-opencast &
 }
 
 case ${1} in

--- a/Dockerfiles/adminpresentation/Dockerfile
+++ b/Dockerfiles/adminpresentation/Dockerfile
@@ -61,7 +61,7 @@ RUN { \
   #   - Tesseract Open Source OCR Engine
   #   - Hunspell
  && apk add --no-cache --virtual .run-deps \
-      su-exec openssl tzdata curl \
+      bash su-exec openssl tzdata curl \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
       ffmpeg \
       sox \

--- a/Dockerfiles/adminpresentation/assets/docker-entrypoint.sh
+++ b/Dockerfiles/adminpresentation/assets/docker-entrypoint.sh
@@ -68,7 +68,27 @@ opencast_main_init() {
 
 opencast_main_start() {
   echo "Run opencast_main_start"
-  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast server
+
+  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast server &
+  OC_PID=$!
+  trap opencast_main_stop TERM INT
+
+  status=0
+
+  set +e
+  while kill -0 "$OC_PID" >/dev/null 2>&1; do
+    wait "$OC_PID"
+    status=$?
+  done
+  set -e
+
+  return $status
+}
+
+opencast_main_stop() {
+  echo "Run opencast_main_stop"
+
+  bin/stop-opencast &
 }
 
 case ${1} in

--- a/Dockerfiles/adminworker/Dockerfile
+++ b/Dockerfiles/adminworker/Dockerfile
@@ -61,7 +61,7 @@ RUN { \
   #   - Tesseract Open Source OCR Engine
   #   - Hunspell
  && apk add --no-cache --virtual .run-deps \
-      su-exec openssl tzdata curl \
+      bash su-exec openssl tzdata curl \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
       ffmpeg \
       sox \

--- a/Dockerfiles/adminworker/assets/docker-entrypoint.sh
+++ b/Dockerfiles/adminworker/assets/docker-entrypoint.sh
@@ -68,7 +68,27 @@ opencast_main_init() {
 
 opencast_main_start() {
   echo "Run opencast_main_start"
-  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast server
+
+  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast server &
+  OC_PID=$!
+  trap opencast_main_stop TERM INT
+
+  status=0
+
+  set +e
+  while kill -0 "$OC_PID" >/dev/null 2>&1; do
+    wait "$OC_PID"
+    status=$?
+  done
+  set -e
+
+  return $status
+}
+
+opencast_main_stop() {
+  echo "Run opencast_main_stop"
+
+  bin/stop-opencast &
 }
 
 case ${1} in

--- a/Dockerfiles/allinone/Dockerfile
+++ b/Dockerfiles/allinone/Dockerfile
@@ -61,7 +61,7 @@ RUN { \
   #   - Tesseract Open Source OCR Engine
   #   - Hunspell
  && apk add --no-cache --virtual .run-deps \
-      su-exec openssl tzdata curl \
+      bash su-exec openssl tzdata curl \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
       ffmpeg \
       sox \

--- a/Dockerfiles/allinone/assets/docker-entrypoint.sh
+++ b/Dockerfiles/allinone/assets/docker-entrypoint.sh
@@ -68,7 +68,27 @@ opencast_main_init() {
 
 opencast_main_start() {
   echo "Run opencast_main_start"
-  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast server
+
+  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast server &
+  OC_PID=$!
+  trap opencast_main_stop TERM INT
+
+  status=0
+
+  set +e
+  while kill -0 "$OC_PID" >/dev/null 2>&1; do
+    wait "$OC_PID"
+    status=$?
+  done
+  set -e
+
+  return $status
+}
+
+opencast_main_stop() {
+  echo "Run opencast_main_stop"
+
+  bin/stop-opencast &
 }
 
 case ${1} in

--- a/Dockerfiles/build/assets/build/docker-entrypoint.sh
+++ b/Dockerfiles/build/assets/build/docker-entrypoint.sh
@@ -68,7 +68,27 @@ opencast_main_init() {
 
 opencast_main_start() {
   echo "Run opencast_main_start"
-  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast server
+
+  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast server &
+  OC_PID=$!
+  trap opencast_main_stop TERM INT
+
+  status=0
+
+  set +e
+  while kill -0 "$OC_PID" >/dev/null 2>&1; do
+    wait "$OC_PID"
+    status=$?
+  done
+  set -e
+
+  return $status
+}
+
+opencast_main_stop() {
+  echo "Run opencast_main_stop"
+
+  bin/stop-opencast &
 }
 
 case ${1} in

--- a/Dockerfiles/ingest/Dockerfile
+++ b/Dockerfiles/ingest/Dockerfile
@@ -61,7 +61,7 @@ RUN { \
   #   - Tesseract Open Source OCR Engine
   #   - Hunspell
  && apk add --no-cache --virtual .run-deps \
-      su-exec openssl tzdata curl \
+      bash su-exec openssl tzdata curl \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
       ffmpeg \
       sox \

--- a/Dockerfiles/ingest/assets/docker-entrypoint.sh
+++ b/Dockerfiles/ingest/assets/docker-entrypoint.sh
@@ -68,7 +68,27 @@ opencast_main_init() {
 
 opencast_main_start() {
   echo "Run opencast_main_start"
-  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast server
+
+  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast server &
+  OC_PID=$!
+  trap opencast_main_stop TERM INT
+
+  status=0
+
+  set +e
+  while kill -0 "$OC_PID" >/dev/null 2>&1; do
+    wait "$OC_PID"
+    status=$?
+  done
+  set -e
+
+  return $status
+}
+
+opencast_main_stop() {
+  echo "Run opencast_main_stop"
+
+  bin/stop-opencast &
 }
 
 case ${1} in

--- a/Dockerfiles/presentation/Dockerfile
+++ b/Dockerfiles/presentation/Dockerfile
@@ -61,7 +61,7 @@ RUN { \
   #   - Tesseract Open Source OCR Engine
   #   - Hunspell
  && apk add --no-cache --virtual .run-deps \
-      su-exec openssl tzdata curl \
+      bash su-exec openssl tzdata curl \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
       ffmpeg \
       sox \

--- a/Dockerfiles/presentation/assets/docker-entrypoint.sh
+++ b/Dockerfiles/presentation/assets/docker-entrypoint.sh
@@ -68,7 +68,27 @@ opencast_main_init() {
 
 opencast_main_start() {
   echo "Run opencast_main_start"
-  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast server
+
+  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast server &
+  OC_PID=$!
+  trap opencast_main_stop TERM INT
+
+  status=0
+
+  set +e
+  while kill -0 "$OC_PID" >/dev/null 2>&1; do
+    wait "$OC_PID"
+    status=$?
+  done
+  set -e
+
+  return $status
+}
+
+opencast_main_stop() {
+  echo "Run opencast_main_stop"
+
+  bin/stop-opencast &
 }
 
 case ${1} in

--- a/Dockerfiles/worker/Dockerfile
+++ b/Dockerfiles/worker/Dockerfile
@@ -61,7 +61,7 @@ RUN { \
   #   - Tesseract Open Source OCR Engine
   #   - Hunspell
  && apk add --no-cache --virtual .run-deps \
-      su-exec openssl tzdata curl \
+      bash su-exec openssl tzdata curl \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
       ffmpeg \
       sox \

--- a/Dockerfiles/worker/assets/docker-entrypoint.sh
+++ b/Dockerfiles/worker/assets/docker-entrypoint.sh
@@ -68,7 +68,27 @@ opencast_main_init() {
 
 opencast_main_start() {
   echo "Run opencast_main_start"
-  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast server
+
+  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast server &
+  OC_PID=$!
+  trap opencast_main_stop TERM INT
+
+  status=0
+
+  set +e
+  while kill -0 "$OC_PID" >/dev/null 2>&1; do
+    wait "$OC_PID"
+    status=$?
+  done
+  set -e
+
+  return $status
+}
+
+opencast_main_stop() {
+  echo "Run opencast_main_stop"
+
+  bin/stop-opencast &
 }
 
 case ${1} in


### PR DESCRIPTION
Opencast currently does not handle `SIGTERM` and `SIGINT` gracefully. Instead it comes with a `stop-opencast` script. This pull request sets up a `trap` in the entrypoint shell script to handle these signals to execute the stop script.