### PR TITLE
Add --cache-from to Travis CI script to speed up builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,14 @@ services:
   - docker
 
 env:
-  - OPENCAST_DISTRIBUTION=allinone
   - OPENCAST_DISTRIBUTION=admin
+  - OPENCAST_DISTRIBUTION=adminpresentation
   - OPENCAST_DISTRIBUTION=adminworker
+  - OPENCAST_DISTRIBUTION=allinone
+  - OPENCAST_DISTRIBUTION=build
   - OPENCAST_DISTRIBUTION=ingest
   - OPENCAST_DISTRIBUTION=presentation
   - OPENCAST_DISTRIBUTION=worker
-  - OPENCAST_DISTRIBUTION=build
 
 addons:
   apt:
@@ -34,6 +35,7 @@ addons:
       - debian-sid
     packages:
       - shellcheck
+      - docker-engine
 
 before_install:
   - git clone https://github.com/sstephenson/bats.git /tmp/bats
@@ -42,7 +44,11 @@ before_install:
   - docker info
   - shellcheck --version
   - bats --version
-install: make "build-${OPENCAST_DISTRIBUTION}"
+
+install:
+  - docker pull "opencast/${OPENCAST_DISTRIBUTION}:$(cat VERSION)" || true
+  - make "build-${OPENCAST_DISTRIBUTION}" CUSTOM_DOCKER_BUILD_ARGS="--cache-from 'opencast/${OPENCAST_DISTRIBUTION}:$(cat VERSION)'"
+
 script:
   - make lint
-  - make test-common "test-${OPENCAST_DISTRIBUTION}"
+  - make test-common "test-${OPENCAST_DISTRIBUTION}" CUSTOM_DOCKER_BUILD_ARGS="--cache-from 'opencast/${OPENCAST_DISTRIBUTION}:$(cat VERSION)'"

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ test-allinone: build-allinone
 test-admin: build-admin
 test-adminpresentation: build-adminpresentation
 test-adminworker: build-adminworker
-test-ingest: build-allinone
+test-ingest: build-ingest
 test-presentation: build-presentation
 test-worker: build-worker
 test-build: build-build


### PR DESCRIPTION
Docker 1.13 allows to specify an image to be used as build cache. This should speed up Travis CI builds.

# WIP
I could not efficiently test this as Travis currently has some API problems causing empty logs.