### PR TITLE
Update docker-compose files

### DIFF
--- a/Dockerfiles/build/Dockerfile
+++ b/Dockerfiles/build/Dockerfile
@@ -114,6 +114,7 @@ RUN dnf -y install \
  && useradd --system -M -N -g "${OPENCAST_GROUP}" -d "${OPENCAST_HOME}" -u "${OPENCAST_UID}" "${OPENCAST_USER}" \
  && mkdir -p "${OPENCAST_SRC}" "${OPENCAST_HOME}" "${OPENCAST_DATA}" "${OPENCAST_BUILD_ASSETS}" \
  && chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_HOME}" "${OPENCAST_DATA}" \
+ && echo "opencast-builder ALL = NOPASSWD: ALL" > /etc/sudoers.d/opencast-builder \
   \
   # Cleanup
  && rm -rf /tmp/* /var/cache/dnf /var/log/dnf* /var/log/hawkey.log

--- a/Dockerfiles/build/assets/docker-entrypoint.sh
+++ b/Dockerfiles/build/assets/docker-entrypoint.sh
@@ -29,11 +29,8 @@ if ! id opencast-builder >/dev/null 2>&1; then
     --uid "${OPENCAST_BUILD_USER_UID}" \
     opencast-builder
 
-  # Make sure the user can read the Opencast source
-  chown -R "${OPENCAST_BUILD_USER_GID}:${OPENCAST_BUILD_USER_UID}" "${OPENCAST_SRC}"
-
-  # Give user sudo rights with no password
-  echo "opencast-builder ALL = NOPASSWD: ALL" > /etc/sudoers.d/opencast-builder
+  # Make sure the user can read the Opencast source and home directory files
+  chown -R "${OPENCAST_BUILD_USER_GID}:${OPENCAST_BUILD_USER_UID}" "${OPENCAST_SRC}" /home/opencast-builder
 fi
 
 su-exec "${OPENCAST_BUILD_USER_UID}:${OPENCAST_BUILD_USER_GID}" "$@"

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Make sure to use the correct Opencast distribution as there are small difference
 * `ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS` **Required**  
   Password for the communication between Opencast nodes and capture agents.
 * `ORG_OPENCASTPROJECT_DOWNLOAD_URL` Optional  
-  The HTTP-URL to use for downloading media files, e.g. for the player. Defaults to `${org.opencastproject.server.url}`.
+  The HTTP-URL to use for downloading media files, e.g. for the player. Defaults to `${org.opencastproject.server.url}/static`.
 
 For an installation with multiple nodes you can also set:
 

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -10,8 +10,9 @@ Within this directory you simply can run these commands to startup an Opencast
 system:
 
 ```sh
-# set an environment variable with a valid IP address to the Docker host
+# Optional: Set an environment variable with a valid IP address/hostname to the Docker host that should be used for the download URL
 $ export HOSTIP=10.25.40.2
+
 $ docker-compose -f <docker-compose-file>.yml up
 ```
 
@@ -30,34 +31,3 @@ ways one can use the Docker images:
   This setup starts a multiserver Opencast distribution with one admin, worker
   and presentation server as well as an Apache ActiveMQ server and an external
   MariaDB server.
-
-### Wait, what? Why do I need to set `HOSTIP`? Why will `localhost` not work?!
-
-If you have the time and want to know what exactly happens, let me explain:
-
-The different Opencast nodes need a way to talk to each other, so that the
-relaying of the different workflow operations works correctly.
-
-The first (and usual) approach to that would be to use the hostnames of the
-containers for those URLs (e.g. `PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL`). If you
-do so, the links to the engage UI that will be generated from the admin UI will
-use those URLs, too. The engage UI as well will try to link the media with one
-of those provided URLs. If you now try to open those in a browser on your host,
-it will fail to resolve the hostname. This is because the hostnames are only
-known to the containers themselves, internally, but not to your host, which is
-external to this environment.
-
-The implemented solution is to agree on a hostname or IP address which is
-reachable and resolvable both internally and externally. The complete
-communication between the nodes will then be routed via this point (hence the
-`EXPORT` on ports `8081` and `8082`). `docker-compose` does not provide a
-(known) way of doing this automatically, so the user needs to find such a
-suitable hostname or IP address themselves and export it to an environment
-variable. This environment variable is then used in the docker-compose file to
-build valid URLs that fulfill the special requirements.
-
-In the multiserver case it is thus a requirement to set `HOSTIP` properly. The
-allinone setups will work with `localhost` assuming the Docker host is reachable
-locally. However on an operating system other than Linux this is not always the
-case. To generalize the setup for all platforms, the `HOSTIP` was also
-introduced to the other compose files.

--- a/docker-compose/docker-compose.allinone.hsql.yml
+++ b/docker-compose/docker-compose.allinone.hsql.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "2"
+version: "3"
 volumes:
   data: {}
 services:
@@ -31,7 +31,8 @@ services:
   opencast:
     image: opencast/allinone:2.3.0
     environment:
-      - ORG_OPENCASTPROJECT_SERVER_URL=http://${HOSTIP}:8080
+      - ORG_OPENCASTPROJECT_SERVER_URL=http://opencast:8080
+      - ORG_OPENCASTPROJECT_DOWNLOAD_URL=http://${HOSTIP:-localhost}:8080/static
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER=admin
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS=opencast
       - ORG_OPENCASTPROJECT_SECURITY_DIGEST_USER=opencast_system_account

--- a/docker-compose/docker-compose.allinone.mariadb.yml
+++ b/docker-compose/docker-compose.allinone.mariadb.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "2"
+version: "3"
 volumes:
   data: {}
 services:
@@ -41,7 +41,8 @@ services:
   opencast:
     image: opencast/allinone:2.3.0
     environment:
-      - ORG_OPENCASTPROJECT_SERVER_URL=http://${HOSTIP}:8080
+      - ORG_OPENCASTPROJECT_SERVER_URL=http://opencast:8080
+      - ORG_OPENCASTPROJECT_DOWNLOAD_URL=http://${HOSTIP:-localhost}:8080/static
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER=admin
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS=opencast
       - ORG_OPENCASTPROJECT_SECURITY_DIGEST_USER=opencast_system_account

--- a/docker-compose/docker-compose.build.yml
+++ b/docker-compose/docker-compose.build.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "2"
+version: "3"
 volumes:
   data: {}
   mvn: {}
@@ -36,7 +36,8 @@ services:
     environment:
       - OPENCAST_BUILD_USER_UID=${OPENCAST_BUILD_USER_UID}
       - OPENCAST_BUILD_USER_GID=${OPENCAST_BUILD_USER_GID}
-      - ORG_OPENCASTPROJECT_SERVER_URL=http://${HOSTIP}:8080
+      - ORG_OPENCASTPROJECT_SERVER_URL=http://opencast:8080
+      - ORG_OPENCASTPROJECT_DOWNLOAD_URL=http://${HOSTIP:-localhost}:8080/static
       - ACTIVEMQ_BROKER_URL=failover://(tcp://activemq:61616)?initialReconnectDelay=2000&maxReconnectAttempts=2
       - ACTIVEMQ_BROKER_USERNAME=admin
       - ACTIVEMQ_BROKER_PASSWORD=password

--- a/docker-compose/docker-compose.build.yml
+++ b/docker-compose/docker-compose.build.yml
@@ -15,7 +15,6 @@
 version: "3"
 volumes:
   data: {}
-  mvn: {}
 services:
   activemq:
     image: webcenter/activemq:5.13.2
@@ -34,16 +33,19 @@ services:
     tty: true
     stdin_open: true
     environment:
-      - OPENCAST_BUILD_USER_UID=${OPENCAST_BUILD_USER_UID}
-      - OPENCAST_BUILD_USER_GID=${OPENCAST_BUILD_USER_GID}
+      - OPENCAST_BUILD_USER_UID=${OPENCAST_BUILD_USER_UID:-1000}
+      - OPENCAST_BUILD_USER_GID=${OPENCAST_BUILD_USER_GID:-1000}
       - ORG_OPENCASTPROJECT_SERVER_URL=http://opencast:8080
       - ORG_OPENCASTPROJECT_DOWNLOAD_URL=http://${HOSTIP:-localhost}:8080/static
       - ACTIVEMQ_BROKER_URL=failover://(tcp://activemq:61616)?initialReconnectDelay=2000&maxReconnectAttempts=2
       - ACTIVEMQ_BROKER_USERNAME=admin
       - ACTIVEMQ_BROKER_PASSWORD=password
+      - KARAF_DEBUG=1
+      - DEFAULT_JAVA_DEBUG_OPTS='-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005'
     ports:
       - "8080:8080"
+      - "5005:5005"
     volumes:
       - data:/data
-      - mvn:/root/.m2
+      - "${M2_REPO:-~/.m2}:/home/opencast-builder/.m2"
       - "${OPENCAST_SRC}:/usr/src/opencast"

--- a/docker-compose/docker-compose.multiserver.mariadb.yml
+++ b/docker-compose/docker-compose.multiserver.mariadb.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "2"
+version: "3"
 volumes:
   data: {}
 services:
@@ -38,10 +38,11 @@ services:
     volumes:
       - ./assets/activemq.xml:/opt/activemq/conf/activemq.xml:ro
 
-  opencastadmin:
+  opencast-admin:
     image: opencast/admin:2.3.0
     environment:
-      - ORG_OPENCASTPROJECT_SERVER_URL=http://${HOSTIP}:8080
+      - ORG_OPENCASTPROJECT_SERVER_URL=http://opencast-admin:8080
+      - ORG_OPENCASTPROJECT_DOWNLOAD_URL=http://${HOSTIP:-localhost}:8080/static
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER=admin
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS=opencast
       - ORG_OPENCASTPROJECT_SECURITY_DIGEST_USER=opencast_system_account
@@ -50,8 +51,8 @@ services:
       - ORG_OPENCASTPROJECT_DB_JDBC_URL=jdbc:mysql://mariadb/opencast
       - ORG_OPENCASTPROJECT_DB_JDBC_USER=opencast
       - ORG_OPENCASTPROJECT_DB_JDBC_PASS=opencast
-      - PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL=http://${HOSTIP}:8080
-      - PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL=http://${HOSTIP}:8081
+      - PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL=http://opencast-admin:8080
+      - PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL=http://opencast-presentation:8080
       - ACTIVEMQ_BROKER_URL=failover://(tcp://activemq:61616)?initialReconnectDelay=2000&maxReconnectAttempts=2
       - ACTIVEMQ_BROKER_USERNAME=admin
       - ACTIVEMQ_BROKER_PASSWORD=password
@@ -60,10 +61,11 @@ services:
     volumes:
       - data:/data
 
-  opencastpresentation:
+  opencast-presentation:
     image: opencast/presentation:2.3.0
     environment:
-      - ORG_OPENCASTPROJECT_SERVER_URL=http://${HOSTIP}:8081
+      - ORG_OPENCASTPROJECT_SERVER_URL=http://opencast-presentation:8080
+      - ORG_OPENCASTPROJECT_DOWNLOAD_URL=http://${HOSTIP:-localhost}:8080/static
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER=admin
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS=opencast
       - ORG_OPENCASTPROJECT_SECURITY_DIGEST_USER=opencast_system_account
@@ -72,8 +74,8 @@ services:
       - ORG_OPENCASTPROJECT_DB_JDBC_URL=jdbc:mysql://mariadb/opencast
       - ORG_OPENCASTPROJECT_DB_JDBC_USER=opencast
       - ORG_OPENCASTPROJECT_DB_JDBC_PASS=opencast
-      - PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL=http://${HOSTIP}:8080
-      - PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL=http://${HOSTIP}:8081
+      - PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL=http://opencast-admin:8080
+      - PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL=http://opencast-presentation:8080
       - ACTIVEMQ_BROKER_URL=failover://(tcp://activemq:61616)?initialReconnectDelay=2000&maxReconnectAttempts=2
       - ACTIVEMQ_BROKER_USERNAME=admin
       - ACTIVEMQ_BROKER_PASSWORD=password
@@ -82,10 +84,11 @@ services:
     volumes:
       - data:/data
 
-  opencastworker:
+  opencast-worker:
     image: opencast/worker:2.3.0
     environment:
-      - ORG_OPENCASTPROJECT_SERVER_URL=http://${HOSTIP}:8082
+      - ORG_OPENCASTPROJECT_SERVER_URL=http://opencast-worker:8080
+      - ORG_OPENCASTPROJECT_DOWNLOAD_URL=http://${HOSTIP:-localhost}:8080/static
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER=admin
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS=opencast
       - ORG_OPENCASTPROJECT_SECURITY_DIGEST_USER=opencast_system_account
@@ -94,12 +97,10 @@ services:
       - ORG_OPENCASTPROJECT_DB_JDBC_URL=jdbc:mysql://mariadb/opencast
       - ORG_OPENCASTPROJECT_DB_JDBC_USER=opencast
       - ORG_OPENCASTPROJECT_DB_JDBC_PASS=opencast
-      - PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL=http://${HOSTIP}:8080
-      - PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL=http://${HOSTIP}:8081
+      - PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL=http://opencast-admin:8080
+      - PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL=http://opencast-presentation:8080
       - ACTIVEMQ_BROKER_URL=failover://(tcp://activemq:61616)?initialReconnectDelay=2000&maxReconnectAttempts=2
       - ACTIVEMQ_BROKER_USERNAME=admin
       - ACTIVEMQ_BROKER_PASSWORD=password
-    ports:
-      - "8082:8080"
     volumes:
       - data:/data


### PR DESCRIPTION
Updates docker-compose files to version 3 and makes `HOSTIP` optional by using Docker's service discovery ability.