### PR TITLE
Add missing dependency for build image

### DIFF
--- a/Dockerfiles/build/Dockerfile
+++ b/Dockerfiles/build/Dockerfile
@@ -57,7 +57,7 @@ RUN dnf -y install \
   \
   # Run deps
  && dnf -y install \
-      openssl tzdata curl \
+      openssl tzdata curl nc \
       fontconfig dejavu-sans-fonts dejavu-sans-mono-fonts dejavu-serif-fonts \
       gnu-free-serif-fonts gnu-free-mono-fonts gnu-free-sans-fonts \
       liberation-fonts linux-libertine-fonts \


### PR DESCRIPTION
The build image did not include `nc`, which is used to shut down Opencast properly.