### PR TITLE
Run variable replacement for custom configuration files

### DIFF
--- a/Dockerfiles/admin/assets/docker-entrypoint.sh
+++ b/Dockerfiles/admin/assets/docker-entrypoint.sh
@@ -62,8 +62,9 @@ opencast_main_init() {
   else
     echo "No custom config found"
     opencast_main_check
-    opencast_main_configure
   fi
+
+  opencast_main_configure
 }
 
 opencast_main_start() {

--- a/Dockerfiles/admin/assets/scripts/helper.sh
+++ b/Dockerfiles/admin/assets/scripts/helper.sh
@@ -37,8 +37,7 @@ opencast_helper_customconfig() {
 }
 
 opencast_helper_copycustomconfig() {
-  rm -rf "${OPENCAST_CONFIG}"
-  cp -r "${OPENCAST_CUSTOM_CONFIG}" "${OPENCAST_CONFIG}"
+  cp -R "${OPENCAST_CUSTOM_CONFIG}"/* "${OPENCAST_CONFIG}"
   chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_CONFIG}"
 }
 
@@ -54,12 +53,13 @@ opencast_helper_checkforvariables() {
   done
 }
 
-# Replaces {{$2...}} with $!2... in file $1
+# Replaces {{$2...}} with $!2... in file $1 if $!2... exists
 opencast_helper_replaceinfile() {
   file="$1"
   shift
   for var in "$@"; do
     eval exp_var="\$${var}"
+    # shellcheck disable=SC2154
     sed -ri "s/[{]{2}${var}[}]{2}/$( echo "${exp_var}" | sed -e 's/[\/&]/\\&/g' )/g" "${file}"
   done
 }

--- a/Dockerfiles/adminpresentation/assets/docker-entrypoint.sh
+++ b/Dockerfiles/adminpresentation/assets/docker-entrypoint.sh
@@ -62,8 +62,9 @@ opencast_main_init() {
   else
     echo "No custom config found"
     opencast_main_check
-    opencast_main_configure
   fi
+
+  opencast_main_configure
 }
 
 opencast_main_start() {

--- a/Dockerfiles/adminpresentation/assets/scripts/helper.sh
+++ b/Dockerfiles/adminpresentation/assets/scripts/helper.sh
@@ -37,8 +37,7 @@ opencast_helper_customconfig() {
 }
 
 opencast_helper_copycustomconfig() {
-  rm -rf "${OPENCAST_CONFIG}"
-  cp -r "${OPENCAST_CUSTOM_CONFIG}" "${OPENCAST_CONFIG}"
+  cp -R "${OPENCAST_CUSTOM_CONFIG}"/* "${OPENCAST_CONFIG}"
   chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_CONFIG}"
 }
 
@@ -54,12 +53,13 @@ opencast_helper_checkforvariables() {
   done
 }
 
-# Replaces {{$2...}} with $!2... in file $1
+# Replaces {{$2...}} with $!2... in file $1 if $!2... exists
 opencast_helper_replaceinfile() {
   file="$1"
   shift
   for var in "$@"; do
     eval exp_var="\$${var}"
+    # shellcheck disable=SC2154
     sed -ri "s/[{]{2}${var}[}]{2}/$( echo "${exp_var}" | sed -e 's/[\/&]/\\&/g' )/g" "${file}"
   done
 }

--- a/Dockerfiles/adminworker/assets/docker-entrypoint.sh
+++ b/Dockerfiles/adminworker/assets/docker-entrypoint.sh
@@ -62,8 +62,9 @@ opencast_main_init() {
   else
     echo "No custom config found"
     opencast_main_check
-    opencast_main_configure
   fi
+
+  opencast_main_configure
 }
 
 opencast_main_start() {

--- a/Dockerfiles/adminworker/assets/scripts/helper.sh
+++ b/Dockerfiles/adminworker/assets/scripts/helper.sh
@@ -37,8 +37,7 @@ opencast_helper_customconfig() {
 }
 
 opencast_helper_copycustomconfig() {
-  rm -rf "${OPENCAST_CONFIG}"
-  cp -r "${OPENCAST_CUSTOM_CONFIG}" "${OPENCAST_CONFIG}"
+  cp -R "${OPENCAST_CUSTOM_CONFIG}"/* "${OPENCAST_CONFIG}"
   chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_CONFIG}"
 }
 
@@ -54,12 +53,13 @@ opencast_helper_checkforvariables() {
   done
 }
 
-# Replaces {{$2...}} with $!2... in file $1
+# Replaces {{$2...}} with $!2... in file $1 if $!2... exists
 opencast_helper_replaceinfile() {
   file="$1"
   shift
   for var in "$@"; do
     eval exp_var="\$${var}"
+    # shellcheck disable=SC2154
     sed -ri "s/[{]{2}${var}[}]{2}/$( echo "${exp_var}" | sed -e 's/[\/&]/\\&/g' )/g" "${file}"
   done
 }

--- a/Dockerfiles/allinone/assets/docker-entrypoint.sh
+++ b/Dockerfiles/allinone/assets/docker-entrypoint.sh
@@ -62,8 +62,9 @@ opencast_main_init() {
   else
     echo "No custom config found"
     opencast_main_check
-    opencast_main_configure
   fi
+
+  opencast_main_configure
 }
 
 opencast_main_start() {

--- a/Dockerfiles/allinone/assets/scripts/helper.sh
+++ b/Dockerfiles/allinone/assets/scripts/helper.sh
@@ -37,8 +37,7 @@ opencast_helper_customconfig() {
 }
 
 opencast_helper_copycustomconfig() {
-  rm -rf "${OPENCAST_CONFIG}"
-  cp -r "${OPENCAST_CUSTOM_CONFIG}" "${OPENCAST_CONFIG}"
+  cp -R "${OPENCAST_CUSTOM_CONFIG}"/* "${OPENCAST_CONFIG}"
   chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_CONFIG}"
 }
 
@@ -54,12 +53,13 @@ opencast_helper_checkforvariables() {
   done
 }
 
-# Replaces {{$2...}} with $!2... in file $1
+# Replaces {{$2...}} with $!2... in file $1 if $!2... exists
 opencast_helper_replaceinfile() {
   file="$1"
   shift
   for var in "$@"; do
     eval exp_var="\$${var}"
+    # shellcheck disable=SC2154
     sed -ri "s/[{]{2}${var}[}]{2}/$( echo "${exp_var}" | sed -e 's/[\/&]/\\&/g' )/g" "${file}"
   done
 }

--- a/Dockerfiles/build/assets/bin/oc_install
+++ b/Dockerfiles/build/assets/bin/oc_install
@@ -41,15 +41,15 @@ log "oc_install" "Create folders"
 sudo mkdir -p "${OPENCAST_CONFIG}" "${OPENCAST_SCRIPTS}" "${OPENCAST_SUPPORT}"
 
 log "oc_install" "Copy Docker scripts"
-sudo cp -r ${OPENCAST_BUILD_ASSETS}/scripts/* "${OPENCAST_SCRIPTS}/"
+sudo cp -R ${OPENCAST_BUILD_ASSETS}/scripts/* "${OPENCAST_SCRIPTS}/"
 sudo cp "${OPENCAST_BUILD_ASSETS}/docker-entrypoint.sh" "${OPENCAST_SCRIPTS}/docker-entrypoint.sh"
 sudo javac "${OPENCAST_SCRIPTS}/TryToConnectToDb.java"
 
 log "oc_install" "Copy support files"
-sudo cp -r ${OPENCAST_BUILD_ASSETS}/support/* "${OPENCAST_SUPPORT}/"
+sudo cp -R ${OPENCAST_BUILD_ASSETS}/support/* "${OPENCAST_SUPPORT}/"
 
 log "oc_install" "Copy configuration"
-sudo cp -r ${OPENCAST_BUILD_ASSETS}/etc/$1/* "${OPENCAST_CONFIG}/"
+sudo cp -R ${OPENCAST_BUILD_ASSETS}/etc/$1/* "${OPENCAST_CONFIG}/"
 sudo cp "${OPENCAST_BUILD_ASSETS}/etc/$1/index/adminui/settings.yml" "${OPENCAST_CONFIG}/index/adminui/"
 sudo cp "${OPENCAST_BUILD_ASSETS}/etc/$1/index/externalapi/settings.yml" "${OPENCAST_CONFIG}/index/externalapi/"
 

--- a/Dockerfiles/build/assets/build/docker-entrypoint.sh
+++ b/Dockerfiles/build/assets/build/docker-entrypoint.sh
@@ -62,8 +62,9 @@ opencast_main_init() {
   else
     echo "No custom config found"
     opencast_main_check
-    opencast_main_configure
   fi
+
+  opencast_main_configure
 }
 
 opencast_main_start() {

--- a/Dockerfiles/build/assets/build/scripts/helper.sh
+++ b/Dockerfiles/build/assets/build/scripts/helper.sh
@@ -37,8 +37,7 @@ opencast_helper_customconfig() {
 }
 
 opencast_helper_copycustomconfig() {
-  rm -rf "${OPENCAST_CONFIG}"
-  cp -r "${OPENCAST_CUSTOM_CONFIG}" "${OPENCAST_CONFIG}"
+  cp -R "${OPENCAST_CUSTOM_CONFIG}"/* "${OPENCAST_CONFIG}"
   chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_CONFIG}"
 }
 
@@ -54,12 +53,13 @@ opencast_helper_checkforvariables() {
   done
 }
 
-# Replaces {{$2...}} with $!2... in file $1
+# Replaces {{$2...}} with $!2... in file $1 if $!2... exists
 opencast_helper_replaceinfile() {
   file="$1"
   shift
   for var in "$@"; do
     eval exp_var="\$${var}"
+    # shellcheck disable=SC2154
     sed -ri "s/[{]{2}${var}[}]{2}/$( echo "${exp_var}" | sed -e 's/[\/&]/\\&/g' )/g" "${file}"
   done
 }

--- a/Dockerfiles/ingest/assets/docker-entrypoint.sh
+++ b/Dockerfiles/ingest/assets/docker-entrypoint.sh
@@ -62,8 +62,9 @@ opencast_main_init() {
   else
     echo "No custom config found"
     opencast_main_check
-    opencast_main_configure
   fi
+
+  opencast_main_configure
 }
 
 opencast_main_start() {

--- a/Dockerfiles/ingest/assets/scripts/helper.sh
+++ b/Dockerfiles/ingest/assets/scripts/helper.sh
@@ -37,8 +37,7 @@ opencast_helper_customconfig() {
 }
 
 opencast_helper_copycustomconfig() {
-  rm -rf "${OPENCAST_CONFIG}"
-  cp -r "${OPENCAST_CUSTOM_CONFIG}" "${OPENCAST_CONFIG}"
+  cp -R "${OPENCAST_CUSTOM_CONFIG}"/* "${OPENCAST_CONFIG}"
   chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_CONFIG}"
 }
 
@@ -54,12 +53,13 @@ opencast_helper_checkforvariables() {
   done
 }
 
-# Replaces {{$2...}} with $!2... in file $1
+# Replaces {{$2...}} with $!2... in file $1 if $!2... exists
 opencast_helper_replaceinfile() {
   file="$1"
   shift
   for var in "$@"; do
     eval exp_var="\$${var}"
+    # shellcheck disable=SC2154
     sed -ri "s/[{]{2}${var}[}]{2}/$( echo "${exp_var}" | sed -e 's/[\/&]/\\&/g' )/g" "${file}"
   done
 }

--- a/Dockerfiles/presentation/assets/docker-entrypoint.sh
+++ b/Dockerfiles/presentation/assets/docker-entrypoint.sh
@@ -62,8 +62,9 @@ opencast_main_init() {
   else
     echo "No custom config found"
     opencast_main_check
-    opencast_main_configure
   fi
+
+  opencast_main_configure
 }
 
 opencast_main_start() {

--- a/Dockerfiles/presentation/assets/scripts/helper.sh
+++ b/Dockerfiles/presentation/assets/scripts/helper.sh
@@ -37,8 +37,7 @@ opencast_helper_customconfig() {
 }
 
 opencast_helper_copycustomconfig() {
-  rm -rf "${OPENCAST_CONFIG}"
-  cp -r "${OPENCAST_CUSTOM_CONFIG}" "${OPENCAST_CONFIG}"
+  cp -R "${OPENCAST_CUSTOM_CONFIG}"/* "${OPENCAST_CONFIG}"
   chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_CONFIG}"
 }
 
@@ -54,12 +53,13 @@ opencast_helper_checkforvariables() {
   done
 }
 
-# Replaces {{$2...}} with $!2... in file $1
+# Replaces {{$2...}} with $!2... in file $1 if $!2... exists
 opencast_helper_replaceinfile() {
   file="$1"
   shift
   for var in "$@"; do
     eval exp_var="\$${var}"
+    # shellcheck disable=SC2154
     sed -ri "s/[{]{2}${var}[}]{2}/$( echo "${exp_var}" | sed -e 's/[\/&]/\\&/g' )/g" "${file}"
   done
 }

--- a/Dockerfiles/worker/assets/docker-entrypoint.sh
+++ b/Dockerfiles/worker/assets/docker-entrypoint.sh
@@ -62,8 +62,9 @@ opencast_main_init() {
   else
     echo "No custom config found"
     opencast_main_check
-    opencast_main_configure
   fi
+
+  opencast_main_configure
 }
 
 opencast_main_start() {

--- a/Dockerfiles/worker/assets/scripts/helper.sh
+++ b/Dockerfiles/worker/assets/scripts/helper.sh
@@ -37,8 +37,7 @@ opencast_helper_customconfig() {
 }
 
 opencast_helper_copycustomconfig() {
-  rm -rf "${OPENCAST_CONFIG}"
-  cp -r "${OPENCAST_CUSTOM_CONFIG}" "${OPENCAST_CONFIG}"
+  cp -R "${OPENCAST_CUSTOM_CONFIG}"/* "${OPENCAST_CONFIG}"
   chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_CONFIG}"
 }
 
@@ -54,12 +53,13 @@ opencast_helper_checkforvariables() {
   done
 }
 
-# Replaces {{$2...}} with $!2... in file $1
+# Replaces {{$2...}} with $!2... in file $1 if $!2... exists
 opencast_helper_replaceinfile() {
   file="$1"
   shift
   for var in "$@"; do
     eval exp_var="\$${var}"
+    # shellcheck disable=SC2154
     sed -ri "s/[{]{2}${var}[}]{2}/$( echo "${exp_var}" | sed -e 's/[\/&]/\\&/g' )/g" "${file}"
   done
 }


### PR DESCRIPTION
This PR allows for two things:

1. Only mount a subset of configuration files
2. Used placeholder in custom configuration files will also be replaced by environment variables