### PR TITLE
Update Travis CI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ addons:
       - debian-sid
     packages:
       - shellcheck
-      - docker-engine
+      - docker-ce
 
 before_install:
   - git clone https://github.com/sstephenson/bats.git /tmp/bats


### PR DESCRIPTION
The package `docker-engine` is now replaced by `dcoker-ce`.