### PR TITLE
Add support for the develop distribution

### DIFF
--- a/Dockerfiles/admin/assets/docker-entrypoint.sh
+++ b/Dockerfiles/admin/assets/docker-entrypoint.sh
@@ -76,7 +76,12 @@ opencast_main_start() {
   # processes are running. We therefore can just clean up the old pid file.
   rm -rf /opencast/data/pid /opencast/instances/instance.properties
 
-  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast server &
+  if opencast_helper_dist_develop; then
+    export DEFAULT_JAVA_DEBUG_OPTS="${DEFAULT_JAVA_DEBUG_OPTS:--Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005}"
+    exec su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast debug
+  fi
+
+  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast daemon &
   OC_PID=$!
   trap opencast_main_stop TERM INT
 

--- a/Dockerfiles/admin/assets/scripts/helper.sh
+++ b/Dockerfiles/admin/assets/scripts/helper.sh
@@ -20,6 +20,10 @@ opencast_helper_dist_allinone() {
   test "${OPENCAST_DISTRIBUTION}" = "allinone"
 }
 
+opencast_helper_dist_develop() {
+  test "${OPENCAST_DISTRIBUTION}" = "develop"
+}
+
 opencast_helper_customconfig() {
   test -d "${OPENCAST_CUSTOM_CONFIG}"
 }

--- a/Dockerfiles/admin/assets/scripts/opencast.sh
+++ b/Dockerfiles/admin/assets/scripts/opencast.sh
@@ -20,7 +20,7 @@ ORG_OPENCASTPROJECT_SERVER_URL="${ORG_OPENCASTPROJECT_SERVER_URL:-http://$(hostn
 ORG_OPENCASTPROJECT_ADMIN_EMAIL="${ORG_OPENCASTPROJECT_ADMIN_EMAIL:-admin@localhost}"
 ORG_OPENCASTPROJECT_DOWNLOAD_URL="${ORG_OPENCASTPROJECT_DOWNLOAD_URL:-\$\{org.opencastproject.server.url\}/static}"
 
-if opencast_helper_dist_allinone; then
+if opencast_helper_dist_allinone || opencast_helper_dist_develop; then
   # shellcheck disable=SC2016
   export ORG_OPENCASTPROJECT_FILE_REPO_URL='${org.opencastproject.server.url}'
 else
@@ -38,7 +38,7 @@ opencast_opencast_check() {
     "ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS" \
     "ORG_OPENCASTPROJECT_FILE_REPO_URL"
 
-  if ! opencast_helper_dist_allinone; then
+  if ! (opencast_helper_dist_allinone || opencast_helper_dist_develop); then
     opencast_helper_checkforvariables \
       "PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL" \
       "PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL"
@@ -57,7 +57,7 @@ opencast_opencast_configure() {
     "ORG_OPENCASTPROJECT_FILE_REPO_URL" \
     "ORG_OPENCASTPROJECT_DOWNLOAD_URL"
 
-  if ! opencast_helper_dist_allinone; then
+  if ! (opencast_helper_dist_allinone || opencast_helper_dist_develop); then
     opencast_helper_replaceinfile "etc/org.opencastproject.organization-mh_default_org.cfg" \
       "PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL" \
       "PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL"

--- a/Dockerfiles/adminpresentation/assets/docker-entrypoint.sh
+++ b/Dockerfiles/adminpresentation/assets/docker-entrypoint.sh
@@ -76,7 +76,12 @@ opencast_main_start() {
   # processes are running. We therefore can just clean up the old pid file.
   rm -rf /opencast/data/pid /opencast/instances/instance.properties
 
-  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast server &
+  if opencast_helper_dist_develop; then
+    export DEFAULT_JAVA_DEBUG_OPTS="${DEFAULT_JAVA_DEBUG_OPTS:--Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005}"
+    exec su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast debug
+  fi
+
+  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast daemon &
   OC_PID=$!
   trap opencast_main_stop TERM INT
 

--- a/Dockerfiles/adminpresentation/assets/scripts/helper.sh
+++ b/Dockerfiles/adminpresentation/assets/scripts/helper.sh
@@ -20,6 +20,10 @@ opencast_helper_dist_allinone() {
   test "${OPENCAST_DISTRIBUTION}" = "allinone"
 }
 
+opencast_helper_dist_develop() {
+  test "${OPENCAST_DISTRIBUTION}" = "develop"
+}
+
 opencast_helper_customconfig() {
   test -d "${OPENCAST_CUSTOM_CONFIG}"
 }

--- a/Dockerfiles/adminpresentation/assets/scripts/opencast.sh
+++ b/Dockerfiles/adminpresentation/assets/scripts/opencast.sh
@@ -20,7 +20,7 @@ ORG_OPENCASTPROJECT_SERVER_URL="${ORG_OPENCASTPROJECT_SERVER_URL:-http://$(hostn
 ORG_OPENCASTPROJECT_ADMIN_EMAIL="${ORG_OPENCASTPROJECT_ADMIN_EMAIL:-admin@localhost}"
 ORG_OPENCASTPROJECT_DOWNLOAD_URL="${ORG_OPENCASTPROJECT_DOWNLOAD_URL:-\$\{org.opencastproject.server.url\}/static}"
 
-if opencast_helper_dist_allinone; then
+if opencast_helper_dist_allinone || opencast_helper_dist_develop; then
   # shellcheck disable=SC2016
   export ORG_OPENCASTPROJECT_FILE_REPO_URL='${org.opencastproject.server.url}'
 else
@@ -38,7 +38,7 @@ opencast_opencast_check() {
     "ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS" \
     "ORG_OPENCASTPROJECT_FILE_REPO_URL"
 
-  if ! opencast_helper_dist_allinone; then
+  if ! (opencast_helper_dist_allinone || opencast_helper_dist_develop); then
     opencast_helper_checkforvariables \
       "PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL" \
       "PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL"
@@ -57,7 +57,7 @@ opencast_opencast_configure() {
     "ORG_OPENCASTPROJECT_FILE_REPO_URL" \
     "ORG_OPENCASTPROJECT_DOWNLOAD_URL"
 
-  if ! opencast_helper_dist_allinone; then
+  if ! (opencast_helper_dist_allinone || opencast_helper_dist_develop); then
     opencast_helper_replaceinfile "etc/org.opencastproject.organization-mh_default_org.cfg" \
       "PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL" \
       "PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL"

--- a/Dockerfiles/adminworker/assets/docker-entrypoint.sh
+++ b/Dockerfiles/adminworker/assets/docker-entrypoint.sh
@@ -76,7 +76,12 @@ opencast_main_start() {
   # processes are running. We therefore can just clean up the old pid file.
   rm -rf /opencast/data/pid /opencast/instances/instance.properties
 
-  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast server &
+  if opencast_helper_dist_develop; then
+    export DEFAULT_JAVA_DEBUG_OPTS="${DEFAULT_JAVA_DEBUG_OPTS:--Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005}"
+    exec su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast debug
+  fi
+
+  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast daemon &
   OC_PID=$!
   trap opencast_main_stop TERM INT
 

--- a/Dockerfiles/adminworker/assets/scripts/helper.sh
+++ b/Dockerfiles/adminworker/assets/scripts/helper.sh
@@ -20,6 +20,10 @@ opencast_helper_dist_allinone() {
   test "${OPENCAST_DISTRIBUTION}" = "allinone"
 }
 
+opencast_helper_dist_develop() {
+  test "${OPENCAST_DISTRIBUTION}" = "develop"
+}
+
 opencast_helper_customconfig() {
   test -d "${OPENCAST_CUSTOM_CONFIG}"
 }

--- a/Dockerfiles/adminworker/assets/scripts/opencast.sh
+++ b/Dockerfiles/adminworker/assets/scripts/opencast.sh
@@ -20,7 +20,7 @@ ORG_OPENCASTPROJECT_SERVER_URL="${ORG_OPENCASTPROJECT_SERVER_URL:-http://$(hostn
 ORG_OPENCASTPROJECT_ADMIN_EMAIL="${ORG_OPENCASTPROJECT_ADMIN_EMAIL:-admin@localhost}"
 ORG_OPENCASTPROJECT_DOWNLOAD_URL="${ORG_OPENCASTPROJECT_DOWNLOAD_URL:-\$\{org.opencastproject.server.url\}/static}"
 
-if opencast_helper_dist_allinone; then
+if opencast_helper_dist_allinone || opencast_helper_dist_develop; then
   # shellcheck disable=SC2016
   export ORG_OPENCASTPROJECT_FILE_REPO_URL='${org.opencastproject.server.url}'
 else
@@ -38,7 +38,7 @@ opencast_opencast_check() {
     "ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS" \
     "ORG_OPENCASTPROJECT_FILE_REPO_URL"
 
-  if ! opencast_helper_dist_allinone; then
+  if ! (opencast_helper_dist_allinone || opencast_helper_dist_develop); then
     opencast_helper_checkforvariables \
       "PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL" \
       "PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL"
@@ -57,7 +57,7 @@ opencast_opencast_configure() {
     "ORG_OPENCASTPROJECT_FILE_REPO_URL" \
     "ORG_OPENCASTPROJECT_DOWNLOAD_URL"
 
-  if ! opencast_helper_dist_allinone; then
+  if ! (opencast_helper_dist_allinone || opencast_helper_dist_develop); then
     opencast_helper_replaceinfile "etc/org.opencastproject.organization-mh_default_org.cfg" \
       "PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL" \
       "PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL"

--- a/Dockerfiles/allinone/assets/docker-entrypoint.sh
+++ b/Dockerfiles/allinone/assets/docker-entrypoint.sh
@@ -76,7 +76,12 @@ opencast_main_start() {
   # processes are running. We therefore can just clean up the old pid file.
   rm -rf /opencast/data/pid /opencast/instances/instance.properties
 
-  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast server &
+  if opencast_helper_dist_develop; then
+    export DEFAULT_JAVA_DEBUG_OPTS="${DEFAULT_JAVA_DEBUG_OPTS:--Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005}"
+    exec su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast debug
+  fi
+
+  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast daemon &
   OC_PID=$!
   trap opencast_main_stop TERM INT
 

--- a/Dockerfiles/allinone/assets/scripts/helper.sh
+++ b/Dockerfiles/allinone/assets/scripts/helper.sh
@@ -20,6 +20,10 @@ opencast_helper_dist_allinone() {
   test "${OPENCAST_DISTRIBUTION}" = "allinone"
 }
 
+opencast_helper_dist_develop() {
+  test "${OPENCAST_DISTRIBUTION}" = "develop"
+}
+
 opencast_helper_customconfig() {
   test -d "${OPENCAST_CUSTOM_CONFIG}"
 }

--- a/Dockerfiles/allinone/assets/scripts/opencast.sh
+++ b/Dockerfiles/allinone/assets/scripts/opencast.sh
@@ -20,7 +20,7 @@ ORG_OPENCASTPROJECT_SERVER_URL="${ORG_OPENCASTPROJECT_SERVER_URL:-http://$(hostn
 ORG_OPENCASTPROJECT_ADMIN_EMAIL="${ORG_OPENCASTPROJECT_ADMIN_EMAIL:-admin@localhost}"
 ORG_OPENCASTPROJECT_DOWNLOAD_URL="${ORG_OPENCASTPROJECT_DOWNLOAD_URL:-\$\{org.opencastproject.server.url\}/static}"
 
-if opencast_helper_dist_allinone; then
+if opencast_helper_dist_allinone || opencast_helper_dist_develop; then
   # shellcheck disable=SC2016
   export ORG_OPENCASTPROJECT_FILE_REPO_URL='${org.opencastproject.server.url}'
 else
@@ -38,7 +38,7 @@ opencast_opencast_check() {
     "ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS" \
     "ORG_OPENCASTPROJECT_FILE_REPO_URL"
 
-  if ! opencast_helper_dist_allinone; then
+  if ! (opencast_helper_dist_allinone || opencast_helper_dist_develop); then
     opencast_helper_checkforvariables \
       "PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL" \
       "PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL"
@@ -57,7 +57,7 @@ opencast_opencast_configure() {
     "ORG_OPENCASTPROJECT_FILE_REPO_URL" \
     "ORG_OPENCASTPROJECT_DOWNLOAD_URL"
 
-  if ! opencast_helper_dist_allinone; then
+  if ! (opencast_helper_dist_allinone || opencast_helper_dist_develop); then
     opencast_helper_replaceinfile "etc/org.opencastproject.organization-mh_default_org.cfg" \
       "PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL" \
       "PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL"

--- a/Dockerfiles/build/assets/bin/is_oc_dist
+++ b/Dockerfiles/build/assets/bin/is_oc_dist
@@ -19,6 +19,7 @@ for dist in \
     "admin" \
     "adminpresentation" \
     "adminworker" \
+    "develop" \
     "ingest" \
     "presentation" \
     "worker" \

--- a/Dockerfiles/build/assets/bin/oc_build
+++ b/Dockerfiles/build/assets/bin/oc_build
@@ -18,7 +18,12 @@ set -e
 
 log "oc_build" "Start building Opencast"
 
+if test "$1" = "dev"; then
+  log "oc_build" "Activatig dev build mode"
+  opts="-Pdev"
+fi
+
 cd "${OPENCAST_SRC}"
-mvn install
+mvn install $opts
 
 log "oc_build" "End building Opencast"

--- a/Dockerfiles/build/assets/bin/oc_install
+++ b/Dockerfiles/build/assets/bin/oc_install
@@ -16,17 +16,18 @@
 
 set -e
 
-if test -z "$1"; then
-  log_err "oc_install" "No distribution given as first argument."
+dist="$1"
+if test -z "$dist"; then
+  log "oc_install" "No distribution given as first argument. Using 'develop'."
+  dist=develop
+fi
+
+if ! is_oc_dist "$dist"; then
+  log_err "oc_install" "$dist is not an Opencast distribution."
   exit 1
 fi
 
-if ! is_oc_dist "$1"; then
-  log_err "oc_install" "$1 is not an Opencast distribution."
-  exit 1
-fi
-
-if is_oc_installed "$1"; then
+if is_oc_installed "$dist"; then
   log_err "oc_install" "There is already an installation. Uninstall first."
   exit 1
 fi
@@ -34,8 +35,14 @@ fi
 log "oc_install" "Start installation"
 cd "${OPENCAST_SRC}"
 
-log "oc_install" "Extract archive"
-sudo tar -xzf build/opencast-dist-$1-*.tar.gz --strip 1 -C "${OPENCAST_HOME}"
+if test "$dist" = "develop"; then
+  log "oc_install" "Linking develop"
+  sudo rmdir "${OPENCAST_HOME}"
+  sudo ln -s /usr/src/opencast/build/opencast-dist-develop-* "${OPENCAST_HOME}"
+else
+  log "oc_install" "Extract archive"
+  sudo tar -xzf build/opencast-dist-$dist-*.tar.gz --strip 1 -C "${OPENCAST_HOME}"
+fi
 
 log "oc_install" "Create folders"
 sudo mkdir -p "${OPENCAST_CONFIG}" "${OPENCAST_SCRIPTS}" "${OPENCAST_SUPPORT}"
@@ -51,13 +58,13 @@ log "oc_install" "Copy support files"
 sudo cp -R ${OPENCAST_BUILD_ASSETS}/support/* "${OPENCAST_SUPPORT}/"
 
 log "oc_install" "Copy configuration"
-sudo cp -R ${OPENCAST_BUILD_ASSETS}/etc/$1/* "${OPENCAST_CONFIG}/"
-sudo cp "${OPENCAST_BUILD_ASSETS}/etc/$1/index/adminui/settings.yml" "${OPENCAST_CONFIG}/index/adminui/"
-sudo cp "${OPENCAST_BUILD_ASSETS}/etc/$1/index/externalapi/settings.yml" "${OPENCAST_CONFIG}/index/externalapi/"
 # shellcheck disable=SC2086
+sudo cp -R ${OPENCAST_BUILD_ASSETS}/etc/$dist/* "${OPENCAST_CONFIG}/"
+sudo cp "${OPENCAST_BUILD_ASSETS}/etc/$dist/index/adminui/settings.yml" "${OPENCAST_CONFIG}/index/adminui/"
+sudo cp "${OPENCAST_BUILD_ASSETS}/etc/$dist/index/externalapi/settings.yml" "${OPENCAST_CONFIG}/index/externalapi/"
 
 log "oc_install" "Write environment file"
-echo "export OPENCAST_DISTRIBUTION=$1" | sudo tee "${OPENCAST_SCRIPTS}/env" > /dev/null
+echo "export OPENCAST_DISTRIBUTION=$dist" | sudo tee "${OPENCAST_SCRIPTS}/env" > /dev/null
 
 log "oc_install" "Set permissions"
 sudo chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_HOME}"

--- a/Dockerfiles/build/assets/bin/oc_uninstall
+++ b/Dockerfiles/build/assets/bin/oc_uninstall
@@ -18,6 +18,8 @@ set -e
 
 log "oc_uninstall" "Start uninstallation"
 
-sudo find "${OPENCAST_HOME:?}" -mindepth 1 -delete
+sudo rm -rf "${OPENCAST_HOME}"
+sudo mkdir -p "${OPENCAST_HOME}"
+sudo chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_HOME}"
 
 log "oc_uninstall" "End uninstallation"

--- a/Dockerfiles/build/assets/build/docker-entrypoint.sh
+++ b/Dockerfiles/build/assets/build/docker-entrypoint.sh
@@ -76,7 +76,12 @@ opencast_main_start() {
   # processes are running. We therefore can just clean up the old pid file.
   rm -rf /opencast/data/pid /opencast/instances/instance.properties
 
-  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast server &
+  if opencast_helper_dist_develop; then
+    export DEFAULT_JAVA_DEBUG_OPTS="${DEFAULT_JAVA_DEBUG_OPTS:--Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005}"
+    exec su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast debug
+  fi
+
+  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast daemon &
   OC_PID=$!
   trap opencast_main_stop TERM INT
 

--- a/Dockerfiles/build/assets/build/etc/develop/custom.properties
+++ b/Dockerfiles/build/assets/build/etc/develop/custom.properties
@@ -1,0 +1,326 @@
+#########################################
+### Opencast configuration properties ###
+#########################################
+
+# The internal URL of this Opencast installation, used to locate services running on this instance and for inter-node
+# communication in distributed setups.
+#
+# Note that while the server.url is the public url of this instance, there is the actual public url of an individual
+# tenant, which is configured in etc/load/org.opencastproject.organization-<tenant id>.cfg with the default tenant id
+# being "mh_default_org".
+#
+# Also note that if this felix installation is proxied behind an Apache HTTPD reverse proxy, and communication is meant
+# to go through that proxy, then server.url should point to the proxy's port (usually 80).
+# Related options (like listening addresses) are located in etc/org.ops4j.pax.web.cfg
+org.opencastproject.server.url={{ORG_OPENCASTPROJECT_SERVER_URL}}
+
+
+######### USER/AUTHENTICATION #########
+
+# The username and password for a system administrator account. If both `user` and `pass` are set, Opencast will create
+# or update that user when started up. If it is commented out, nothing will happen.
+# WARNING: Commenting this out later or renaming the user will *not* remove already created user.
+org.opencastproject.security.admin.user={{ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER}}
+org.opencastproject.security.admin.pass={{ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS}}
+org.opencastproject.security.admin.roles=ROLE_ADMIN,ROLE_OAUTH_USER
+
+# Email address of the server's admin.
+org.opencastproject.admin.email={{ORG_OPENCASTPROJECT_ADMIN_EMAIL}}
+
+# Optional custom roles which can used in ACLs and granted to users or groups (comma-separated list of role names)
+#org.opencastproject.security.custom.roles=ROLE_ONE, ROLE_TWO, ROLE_THREE
+
+# Optional custom roles pattern (regular expression). Roles matching this pattern can be added to ACLs.
+#org.opencastproject.security.custom.roles.pattern=^[0-9a-f-]+_(Learner|Instructor)$
+
+# The username and password to present to other Opencast servers when calling their REST endpoints.  The remote server
+# must contain matching values.
+org.opencastproject.security.digest.user={{ORG_OPENCASTPROJECT_SECURITY_DIGEST_USER}}
+org.opencastproject.security.digest.pass={{ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS}}
+
+
+######### STORAGE #########
+
+# The directory where the system will store its processed files (including temporary files).  This directory should
+# be persistent between reboots (i.e., not /tmp)
+org.opencastproject.storage.dir=/data/opencast
+
+# The path to the archive repository
+#org.opencastproject.episode.rootdir=${org.opencastproject.storage.dir}/archive
+
+# The path to the repository of files used during media processing.
+#org.opencastproject.file.repo.path=${org.opencastproject.storage.dir}/files
+
+# The path to the working files (recommend using fast, transient storage)
+org.opencastproject.workspace.rootdir=${org.opencastproject.storage.dir}/workspace
+
+# The location to store uploaded static files such as images and videos.
+org.opencastproject.staticfiles.rootdir=${org.opencastproject.storage.dir}/staticfiles
+
+
+# The ID of the default workflow definition to run when media are ingested
+#org.opencastproject.workflow.default.definition=ng-schedule-and-upload
+
+
+######### STREAMING AND DOWNLOAD #########
+
+# The base URL of the streaming server (ususally "rtmp://<SERVER_URL>/matterhorn-engage").
+# ${org.opencastproject.server.url} can not be used, because the streaming server does not use the HTTP protocol.
+# Streaming is not included in the default workflow, since the Red5 streaming server is a 3rd party component that
+# requires separate installation.
+#org.opencastproject.streaming.url=rtmp://localhost/matterhorn-engage
+
+# The directory where Opencast stores the streams
+#org.opencastproject.streaming.directory=${org.opencastproject.storage.dir}/streams
+
+# The port to use for the streaming server, only used by a Wowza streaming server.
+#org.opencastproject.streaming.port=1935
+
+# Some newer streaming server versions expect an "flv:" tag within the rtmp URL.
+# Not every RTMP-streaming server is compatible with this (i.e. nginx), so this
+# is the compatibility mode to the old syntax.
+# true  = without "flv:" tag - old syntax
+# false = with    "flv:" tag - new syntax
+#org.opencastproject.streaming.flvcompatibility=true
+
+# The base URL for media downloads.
+org.opencastproject.download.url={{ORG_OPENCASTPROJECT_DOWNLOAD_URL}}
+
+# The directory to store media, metadata, and attachments for download from the engage tool
+org.opencastproject.download.directory=${org.opencastproject.storage.dir}/downloads
+
+
+######### DATABASE #########
+
+# Relational Database configuration.  By default, Opencast uses an embedded H2 database.  A standalone database server
+# is recommended for production systems.  If you run the ddl script for your db vendor (see docs/scripts/ddl/) manually,
+# (this is recommended) set 'ddl-generation' to 'false'.
+org.opencastproject.db.ddl.generation={{ORG_OPENCASTPROJECT_DB_DDL_GENERATION}}
+
+# db.vendor can be any of the values listed at under the "eclipselink.target-database" section of
+# http://www.eclipse.org/eclipselink/documentation/2.4/jpa/extensions/p_target_database.htm#target-database
+# Common values include MySQL, PostgreSQL.
+org.opencastproject.db.vendor={{ORG_OPENCASTPROJECT_DB_VENDOR}}
+
+# Opencast comes with the jdbc drivers for MySQL (com.mysql.jdbc.Driver) and PostgreSQL (org.postgresql.Driver). To add
+# other jdbcDrivers to the Opencast runtime, rebuild the matterhorn-db module with your desired drivers.
+org.opencastproject.db.jdbc.driver={{ORG_OPENCASTPROJECT_DB_JDBC_DRIVER}}
+
+# The jdbc connection url, username, and password
+org.opencastproject.db.jdbc.url={{ORG_OPENCASTPROJECT_DB_JDBC_URL}}
+org.opencastproject.db.jdbc.user={{ORG_OPENCASTPROJECT_DB_JDBC_USER}}
+org.opencastproject.db.jdbc.pass={{ORG_OPENCASTPROJECT_DB_JDBC_PASS}}
+
+# The jdbc connection pool properties. See http://www.mchange.com/projects/c3p0/#basic_pool_configuration
+# max.idle.time should be lower than the database server idle connection timeout duration (wait_timeout for mysql)
+#org.opencastproject.db.jdbc.pool.max.size=15
+#org.opencastproject.db.jdbc.pool.min.size=3
+#org.opencastproject.db.jdbc.pool.acquire.increment=3
+#org.opencastproject.db.jdbc.pool.max.statements=0
+#org.opencastproject.db.jdbc.pool.login.timeout=1000
+#org.opencastproject.db.jdbc.pool.max.idle.time=3600
+#org.opencastproject.db.jdbc.pool.max.connection.age=0
+
+
+# Command for shutting down Opencast. If the shutdown port is enabled, Opencast will listen for this command to initiate
+# the shut down procedure.
+# Change this to something secret
+karaf.shutdown.command=3500d4e3-ce93-4ae3-abb4-5e90cef4deb
+
+
+# This is the maximum allowable size in bytes for a file to be uploaded. If the property is missing or set to 0 it is
+# disabled.
+# Default is 1000000000 which is 1GB.
+#org.opencastproject.staticfiles.upload.max.size=1000000000
+
+# The base URL of the file server.  When using a shared filesystem between servers, set all servers to use the same URL.
+# Only then will hard linking between the working file repository and the workspace be enabled to prevent downloads.
+org.opencastproject.file.repo.url={{ORG_OPENCASTPROJECT_FILE_REPO_URL}}
+
+# The max number of ingests to allow at the same time. If more ingests try than the max they will receive service
+# unavailable. A value of 0 means that the server will accept all ingests.
+# Default: 0
+#org.opencastproject.ingest.max.concurrent=0
+
+# Send server configuration data to the Opencast project to help us track how people are using Opencast.  No security
+# related information will be sent to the opencast project.  Comment this out to disable this feature.
+#org.opencastproject.anonymous.feedback.url=http://opencast.org/form/tracking
+
+# The maximum number of concurrent files to ingest from the inbox directory
+# Default: 1
+#org.opencastproject.inbox.threads=1
+
+# The scheduled period in seconds, at which a workspace cleanup operation is performed.
+# 86400 seconds equals 24 hours.
+# Default value: -1 (Disable cleanup scheduler)
+org.opencastproject.workspace.cleanup.period=86400
+
+# The maximum age a file must reach in seconds before a deletion of the file in the workspace cleanup operation is
+# performed. 2592000 seconds equals 30 days.
+# Default value: -1 (max age will never be reached)
+org.opencastproject.workspace.cleanup.max.age=2592000
+
+
+######### ACTIVE MQ BROKER #########
+
+# This configures the connection to the Active MQ broker so that we can send and receive messages.
+# There are many settings for specifying the broker url: http://activemq.apache.org/activemq-4-connection-uris.html
+# Including with failover support details here: http://activemq.apache.org/failover-transport-reference.html
+# Default (url): failover://(tcp://127.0.0.1:61616)?initialReconnectDelay=2000&maxReconnectAttempts=2
+# Default (username/password): None
+activemq.broker.url={{ACTIVEMQ_BROKER_URL}}
+activemq.broker.username={{ACTIVEMQ_BROKER_USERNAME}}
+activemq.broker.password={{ACTIVEMQ_BROKER_PASSWORD}}
+
+# The directory where the configuration files for the Elasticsearch indices are located. This directory should
+# be persistent between reboots (i.e., not /tmp)
+org.opencastproject.elasticsearch.config.dir=${karaf.etc}/index
+
+
+######### SOLR #########
+
+# Default directory to use for embedded solr indexes.
+# If not set, ${karaf.data}/solr-indexes will be used.
+org.opencastproject.solr.dir=/data/solr-indexes
+
+# Directory to store the embedded solr indices.  This should be a persistent and stable directory.
+# Default: ${org.opencastproject.solr.dir}/{archive, search, series, scheduler, workflow}
+#org.opencastproject.archive.solr.dir=${org.opencastproject.solr.dir}/archive
+#org.opencastproject.scheduler.solr.dir=${org.opencastproject.solr.dir}/scheduler
+#org.opencastproject.search.solr.dir=${org.opencastproject.solr.dir}/search
+#org.opencastproject.series.solr.dir=${org.opencastproject.solr.dir}/series
+#org.opencastproject.workflow.solr.dir=${org.opencastproject.solr.dir}/workflow
+
+# URLs of dedicated Solr server to use.  Note that if thesw URLs are specified, the local embedded Solr index as
+# configured using `org.opencastproject.*.solr.dir` will be ignored. A dedicated Solr server should be set up in order
+# to enable running multiple instances of the related service. Please consult http://lucene.apache.org/solr/ on how to
+# set up a standalone Solr server.
+#org.opencastproject.archive.solr.url=http://localhost:8983/solr/
+#org.opencastproject.scheduler.solr.url=http://localhost:8983/solr/
+#org.opencastproject.search.solr.url=http://localhost:8983/solr/
+#org.opencastproject.series.solr.url=http://localhost:8983/solr/
+#org.opencastproject.workflow.solr.url=http://localhost:8983/solr/
+
+
+# The url of the remote service registry.  This is used in cases where there is no direct connection to the service
+# registry database such as capture agens running in protected environments. This is typically true for capture agents
+# and should be set to the url of a server running the actual implementation of the service registry and the path to
+# the service registry(admin, worker, etc. See the build profiles in pom.xml for a complete list).
+#org.opencastproject.serviceregistry.url=${org.opencastproject.server.url}/services
+
+# The base URL to use for publishing job locations. If left commented out, the local server URL will be used.  Set this
+# if you intend to support swapping servers with different IPs or host names.
+#org.opencastproject.jobs.url=${org.opencastproject.server.url}
+
+# The mount point of the OAI-PMH servlet.
+# Please make sure that the path configured is accessible without any login (see security.xml)
+# This setting is configured here and not in the OAI-PMH server's config since it is shared amongst several
+# OAI-PMH related components.
+#org.opencastproject.oaipmh.mountpoint=/oaipmh
+
+# Whether to accept a job whose load exceeds the host's max load
+# Default: true
+#org.opencastproject.job.load.acceptexceeding=true
+
+# The number of times to retry a request if the nonce expires.
+#org.opencastproject.security.digest.nonce.retries=12
+
+# The configuration property specifying the minimum amount of time in seconds wait before retrying a request after
+# a nonce timeout. Default is 300 seconds (5 minutes).
+#org.opencastproject.security.digest.nonce.base.time=300
+
+# The maximum amount of time to wait in addition to the base time for a random generator to add after a nonce timeout
+# so that requests that timeout won't all try again at exactly the same time. Default is 300 seconds (5 minutes).
+#org.opencastproject.security.digest.nonce.variable.time=300
+
+# This changes the number of seconds from when an internal request is made until a signed URL will expire. More
+# specifically, the HTTP client needs access to internal storage areas such as the working file repository as well as to
+# distributed artifacts on the downloads and streaming servers, all of which are protected by verification components.
+# Default is 60 seconds as it shouldn't take longer than that to make a request to a server. This will have no impact on
+# a system where url signing is not configured. For more information please see:
+# http://docs.opencast.org/latest/admin/configuration/stream-security/#configuration-of-url-signing-timeout-values
+#org.opencastproject.security.internal.url.signing.duration=60
+
+# Path to the ffmpeg binary. Its name is sufficient if the binary is in the
+# system path (default: ffmpeg)
+#org.opencastproject.composer.ffmpeg.path=/opt/ffmpeg/ffmpeg
+
+# Path to the ffprobe binary. Its name is sufficient if the binary is in the
+# system path (default: ffprobe)
+#org.opencastproject.inspection.ffprobe.path=/opt/ffmpeg/ffprobe
+
+# Path to the tesseract binary used by the text analyzer. Its name is
+# sufficient if the binary is in the system path (default: tesseract)
+#org.opencastproject.textanalyzer.tesseract.path=/opt/tesseract/tesseract
+
+# Additional options for Tesseract like language or page segmentation mode.
+# The default are no additional options.
+#org.opencastproject.textanalyzer.tesseract.options=-l eng -psm 3
+
+# Path to the hunspell binary used by the matterhorn-dictionary-hunspell
+# module. The default ist just "hunspell" which requires hunspell to be in the
+# search path.
+#org.opencastproject.dictionary.hunspell.binary=/opt/hunspell/hunspell
+
+# Command to use for filtering text by the matterhorn-dictionary-hunspell
+# module. The command is appended to the hunspell binary path. It should filter
+# the text from stdin and print the recognized words to stdout. Usually this
+# should be a combination of "-G" and a list of dictionaries. The default is to
+# use "-d de_DE,en_GB,en_US -G".
+#org.opencastproject.dictionary.hunspell.command=-i utf-8 -d de_DE,en_GB,en_US -G
+
+# The path for SoX command line used by audio normalization
+#org.opencastproject.sox.path=/opt/sox/sox
+
+# Location of the temporary directory to build zip archives.
+# Default: ${org.opencastproject.storage.dir}/tmp/zip
+#org.opencastproject.workflow.handler.workflow.ZipWorkflowOperationHandler.tmpdir=${org.opencastproject.storage.dir}/tmp/zip
+
+# Whether opencast should import test-data by the given csv file path.
+# Default: false
+#org.opencastproject.dataloader.testdata=false
+
+# The path to the CSV file to import the data from it
+org.opencastproject.dataloader.csv=${karaf.etc}/dataimport
+
+# True means to use a webserver to serve the static files but this will not secure
+# any of the files using user or organization security. If false it uses
+# Opencast endpoints to serve and secure the files.
+#org.opencastproject.staticfiles.webserver.enabled=false
+
+# The url to the location where the webserver serves the static file uploads from. It will add the organization and uuid
+# for the uploaded static file. If not set Opencast uses endpoints to serve and secure the files.
+#org.opencastproject.staticfiles.webserver.url=${org.opencastproject.server.url}/staticfiles/
+
+# Timeout for capture agent status, in minutes.
+# Capture agents which have not sent status updates for this period will be marked as offline.
+# Default: 120 minutes (2 hours)
+#org.opencastproject.capture.admin.timeout=120
+
+# The size of the user directory cache.
+# Default: 200
+#org.opencastproject.userdirectory.cache.size=200
+
+# The expiry time of entries in the user directory cache, in minutes
+# Default: 1 minute
+#org.opencastproject.userdirectory.cache.expiry=1
+
+
+######### KARAF CONFIGURATION #########
+
+# The place for Karaf to put the lock file ensuring that Opencast is not run twice at the same time.
+karaf.lock.dir=${karaf.data}
+
+# Setting or deactivating the remote shutdown port in Apache Karaf. Commenting this out will make Karaf listen to a
+# random shutdown port on localhost, announcing it via ${karaf.shutdown.port.file}. Setting this to -1 will deactivate
+# the shutdown port. Note that the stop script is based on this and will not work any longer if the port is deactivated.
+#karaf.shutdown.port=-1
+
+# Specifies the location of the port file for Opencast. It is used by the shutdown script to send the shutdown command
+# to the main process.
+karaf.shutdown.port.file=${karaf.data}/port
+
+# Specifies the location of the PID file for Opencast. It is used by the shutdown script to synchronously shut down
+# Opencast as it will wait for the process with the given process id. Removing this will cause the network port to be
+# used as fallback.
+karaf.pid.file=${karaf.data}/pid

--- a/Dockerfiles/build/assets/build/etc/develop/index/adminui/settings.yml
+++ b/Dockerfiles/build/assets/build/etc/develop/index/adminui/settings.yml
@@ -1,0 +1,391 @@
+##################### Elasticsearch Configuration Example #####################
+
+# This file contains an overview of various configuration settings,
+# targeted at operations staff. Application developers should
+# consult the guide at <http://elasticsearch.org/guide>.
+#
+# The installation procedure is covered at
+# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/setup.html>.
+#
+# Elasticsearch comes with reasonable defaults for most settings,
+# so you can try it out without bothering with configuration.
+#
+# Most of the time, these defaults are just fine for running a production
+# cluster. If you're fine-tuning your cluster, or wondering about the
+# effect of certain configuration option, please _do ask_ on the
+# mailing list or IRC channel [http://elasticsearch.org/community].
+
+# Any element in the configuration can be replaced with environment variables
+# by placing them in ${...} notation. For example:
+#
+#node.rack: ${RACK_ENV_VAR}
+
+# For information on supported formats and syntax for the config file, see
+# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/setup-configuration.html>
+
+
+################################### Cluster ###################################
+
+# Cluster name identifies your cluster for auto-discovery. If you're running
+# multiple clusters on the same network, make sure you're using unique names.
+#
+cluster.name: opencast
+
+
+#################################### Node #####################################
+
+# Node names are generated dynamically on startup, so you're relieved
+# from configuring them manually. You can tie this node to a specific name:
+#
+#node.name: "Localhost"
+
+# Every node can be configured to allow or deny being eligible as the master,
+# and to allow or deny to store the data.
+#
+# Allow this node to be eligible as a master node (enabled by default):
+#
+#node.master: true
+#
+# Allow this node to store data (enabled by default):
+#
+#node.data: true
+
+# You can exploit these settings to design advanced cluster topologies.
+#
+# 1. You want this node to never become a master node, only to hold data.
+#    This will be the "workhorse" of your cluster.
+#
+#node.master: false
+#node.data: true
+#
+# 2. You want this node to only serve as a master: to not store any data and
+#    to have free resources. This will be the "coordinator" of your cluster.
+#
+#node.master: true
+#node.data: false
+#
+# 3. You want this node to be neither master nor data node, but
+#    to act as a "search load balancer" (fetching data from nodes,
+#    aggregating results, etc.)
+#
+#node.master: false
+#node.data: false
+
+# Use the Cluster Health API [http://localhost:9200/_cluster/health], the
+# Node Info API [http://localhost:9200/_nodes] or GUI tools
+# such as <http://www.elasticsearch.org/overview/marvel/>,
+# <http://github.com/karmi/elasticsearch-paramedic>,
+# <http://github.com/lukas-vlcek/bigdesk> and
+# <http://mobz.github.com/elasticsearch-head> to inspect the cluster state.
+
+# A node can have generic attributes associated with it, which can later be used
+# for customized shard allocation filtering, or allocation awareness. An attribute
+# is a simple key value pair, similar to node.key: value, here is an example:
+#
+#node.rack: rack314
+
+# By default, multiple nodes are allowed to start from the same installation location
+# to disable it, set the following:
+#node.max_local_storage_nodes: 1
+
+
+#################################### Index ####################################
+
+# You can set a number of options (such as shard/replica options, mapping
+# or analyzer definitions, translog settings, ...) for indices globally,
+# in this file.
+#
+# Note, that it makes more sense to configure index settings specifically for
+# a certain index, either when creating it or by using the index templates API.
+#
+# See <http://elasticsearch.org/guide/en/elasticsearch/reference/current/index-modules.html> and
+# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/indices-create-index.html>
+# for more information.
+
+# Set the number of shards (splits) of an index (5 by default):
+#
+index.number_of_shards: 1
+
+# Set the number of replicas (additional copies) of an index (1 by default):
+#
+index.number_of_replicas: 0
+
+# Note, that for development on a local machine, with small indices, it usually
+# makes sense to "disable" the distributed features:
+#
+#index.number_of_shards: 1
+#index.number_of_replicas: 0
+
+# These settings directly affect the performance of index and search operations
+# in your cluster. Assuming you have enough machines to hold shards and
+# replicas, the rule of thumb is:
+#
+# 1. Having more *shards* enhances the _indexing_ performance and allows to
+#    _distribute_ a big index across machines.
+# 2. Having more *replicas* enhances the _search_ performance and improves the
+#    cluster _availability_.
+#
+# The "number_of_shards" is a one-time setting for an index.
+#
+# The "number_of_replicas" can be increased or decreased anytime,
+# by using the Index Update Settings API.
+#
+# Elasticsearch takes care about load balancing, relocating, gathering the
+# results from nodes, etc. Experiment with different settings to fine-tune
+# your setup.
+
+# Use the Index Status API (<http://localhost:9200/A/_status>) to inspect
+# the index status.
+
+
+#################################### Paths ####################################
+
+# Path to directory containing configuration (this file and logging.yml):
+#
+path.conf: ${karaf.etc}/index/adminui
+
+# Path to directory where to store index data allocated for this node.
+#
+#path.data: /path/to/data
+#
+# Can optionally include more than one location, causing data to be striped across
+# the locations (a la RAID 0) on a file level, favouring locations with most free
+# space on creation. For example:
+#
+path.data: /data/index/data
+
+# Path to temporary files:
+#
+path.work: /data/index/adminui
+
+# Path to log files:
+#
+path.logs: /data/log/elasticsearch.log
+
+# Path to where plugins are installed:
+#
+#path.plugins: /path/to/plugins
+
+
+#################################### Plugin ###################################
+
+# If a plugin listed here is not installed for current node, the node will not start.
+#
+#plugin.mandatory: mapper-attachments,lang-groovy
+
+
+################################### Memory ####################################
+
+# Elasticsearch performs poorly when JVM starts swapping: you should ensure that
+# it _never_ swaps.
+#
+# Set this property to true to lock the memory:
+#
+#bootstrap.mlockall: true
+
+# Make sure that the ES_MIN_MEM and ES_MAX_MEM environment variables are set
+# to the same value, and that the machine has enough memory to allocate
+# for Elasticsearch, leaving enough memory for the operating system itself.
+#
+# You should also make sure that the Elasticsearch process is allowed to lock
+# the memory, eg. by using `ulimit -l unlimited`.
+
+
+############################## Network And HTTP ###############################
+
+# Elasticsearch, by default, binds itself to the 0.0.0.0 address, and listens
+# on port [9200-9300] for HTTP traffic and on port [9300-9400] for node-to-node
+# communication. (the range means that if the port is busy, it will automatically
+# try the next port).
+
+# Set the bind address specifically (IPv4 or IPv6):
+#
+#network.bind_host: 192.168.0.1
+
+# Set the address other nodes will use to communicate with this node. If not
+# set, it is automatically derived. It must point to an actual IP address.
+#
+#network.publish_host: 192.168.0.1
+
+# Set both 'bind_host' and 'publish_host':
+#
+network.host: 127.0.0.1
+
+# Set a custom port for the node to node communication (9300 by default):
+#
+#transport.tcp.port: 9300
+
+# Enable compression for all communication between nodes (disabled by default):
+#
+#transport.tcp.compress: true
+
+# Set a custom port to listen for HTTP traffic:
+#
+#http.port: 9200
+
+# Set a custom allowed content length:
+#
+#http.max_content_length: 100mb
+
+# Disable HTTP completely:
+#
+#http.enabled: false
+
+
+################################### Gateway ###################################
+
+# The gateway allows for persisting the cluster state between full cluster
+# restarts. Every change to the state (such as adding an index) will be stored
+# in the gateway, and when the cluster starts up for the first time,
+# it will read its state from the gateway.
+
+# There are several types of gateway implementations. For more information, see
+# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/modules-gateway.html>.
+
+# The default gateway type is the "local" gateway (recommended):
+#
+#gateway.type: local
+
+# Settings below control how and when to start the initial recovery process on
+# a full cluster restart (to reuse as much local data as possible when using shared
+# gateway).
+
+# Allow recovery process after N nodes in a cluster are up:
+#
+#gateway.recover_after_nodes: 1
+
+# Set the timeout to initiate the recovery process, once the N nodes
+# from previous setting are up (accepts time value):
+#
+#gateway.recover_after_time: 5m
+
+# Set how many nodes are expected in this cluster. Once these N nodes
+# are up (and recover_after_nodes is met), begin recovery process immediately
+# (without waiting for recover_after_time to expire):
+#
+#gateway.expected_nodes: 2
+
+
+############################# Recovery Throttling #############################
+
+# These settings allow to control the process of shards allocation between
+# nodes during initial recovery, replica allocation, rebalancing,
+# or when adding and removing nodes.
+
+# Set the number of concurrent recoveries happening on a node:
+#
+# 1. During the initial recovery
+#
+#cluster.routing.allocation.node_initial_primaries_recoveries: 4
+#
+# 2. During adding/removing nodes, rebalancing, etc
+#
+#cluster.routing.allocation.node_concurrent_recoveries: 2
+
+# Set to throttle throughput when recovering (eg. 100mb, by default 20mb):
+#
+#indices.recovery.max_bytes_per_sec: 20mb
+
+# Set to limit the number of open concurrent streams when
+# recovering a shard from a peer:
+#
+#indices.recovery.concurrent_streams: 5
+
+
+################################## Discovery ##################################
+
+# Discovery infrastructure ensures nodes can be found within a cluster
+# and master node is elected. Multicast discovery is the default.
+
+# Set to ensure a node sees N other master eligible nodes to be considered
+# operational within the cluster. Its recommended to set it to a higher value
+# than 1 when running more than 2 nodes in the cluster.
+#
+#discovery.zen.minimum_master_nodes: 1
+
+# Set the time to wait for ping responses from other nodes when discovering.
+# Set this option to a higher value on a slow or congested network
+# to minimize discovery failures:
+#
+#discovery.zen.ping.timeout: 3s
+
+# For more information, see
+# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/modules-discovery-zen.html>
+
+# Unicast discovery allows to explicitly control which nodes will be used
+# to discover the cluster. It can be used when multicast is not present,
+# or to restrict the cluster communication-wise.
+#
+# 1. Disable multicast discovery (enabled by default):
+#
+#discovery.zen.ping.multicast.enabled: false
+#
+# 2. Configure an initial list of master nodes in the cluster
+#    to perform discovery when new nodes (master or data) are started:
+#
+#discovery.zen.ping.unicast.hosts: ["host1", "host2:port"]
+
+# EC2 discovery allows to use AWS EC2 API in order to perform discovery.
+#
+# You have to install the cloud-aws plugin for enabling the EC2 discovery.
+#
+# For more information, see
+# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/modules-discovery-ec2.html>
+#
+# See <http://elasticsearch.org/tutorials/elasticsearch-on-ec2/>
+# for a step-by-step tutorial.
+
+# GCE discovery allows to use Google Compute Engine API in order to perform discovery.
+#
+# You have to install the cloud-gce plugin for enabling the GCE discovery.
+#
+# For more information, see <https://github.com/elasticsearch/elasticsearch-cloud-gce>.
+
+# Azure discovery allows to use Azure API in order to perform discovery.
+#
+# You have to install the cloud-azure plugin for enabling the Azure discovery.
+#
+# For more information, see <https://github.com/elasticsearch/elasticsearch-cloud-azure>.
+
+################################## Slow Log ##################################
+
+# Shard level query and fetch threshold logging.
+
+#index.search.slowlog.threshold.query.warn: 10s
+#index.search.slowlog.threshold.query.info: 5s
+#index.search.slowlog.threshold.query.debug: 2s
+#index.search.slowlog.threshold.query.trace: 500ms
+
+#index.search.slowlog.threshold.fetch.warn: 1s
+#index.search.slowlog.threshold.fetch.info: 800ms
+#index.search.slowlog.threshold.fetch.debug: 500ms
+#index.search.slowlog.threshold.fetch.trace: 200ms
+
+#index.indexing.slowlog.threshold.index.warn: 10s
+#index.indexing.slowlog.threshold.index.info: 5s
+#index.indexing.slowlog.threshold.index.debug: 2s
+#index.indexing.slowlog.threshold.index.trace: 500ms
+
+################################## GC Logging ################################
+
+#monitor.jvm.gc.young.warn: 1000ms
+#monitor.jvm.gc.young.info: 700ms
+#monitor.jvm.gc.young.debug: 400ms
+
+#monitor.jvm.gc.old.warn: 10s
+#monitor.jvm.gc.old.info: 5s
+#monitor.jvm.gc.old.debug: 2s
+
+################################## Security ###################################
+
+# Uncomment if you want to enable JSONP as a valid return transport on the
+# http server. With this enabled, it may pose a security risk, so disabling
+# it unless you need it is recommended (it is disabled by default).
+#
+#http.jsonp.enable: true
+
+
+################################## Shutdown ###################################
+
+# Disable the Elasticsearch Shutdown API (recomended).
+action.disable_shutdown: true

--- a/Dockerfiles/build/assets/build/etc/develop/index/externalapi/settings.yml
+++ b/Dockerfiles/build/assets/build/etc/develop/index/externalapi/settings.yml
@@ -1,0 +1,391 @@
+##################### Elasticsearch Configuration Example #####################
+
+# This file contains an overview of various configuration settings,
+# targeted at operations staff. Application developers should
+# consult the guide at <http://elasticsearch.org/guide>.
+#
+# The installation procedure is covered at
+# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/setup.html>.
+#
+# Elasticsearch comes with reasonable defaults for most settings,
+# so you can try it out without bothering with configuration.
+#
+# Most of the time, these defaults are just fine for running a production
+# cluster. If you're fine-tuning your cluster, or wondering about the
+# effect of certain configuration option, please _do ask_ on the
+# mailing list or IRC channel [http://elasticsearch.org/community].
+
+# Any element in the configuration can be replaced with environment variables
+# by placing them in ${...} notation. For example:
+#
+#node.rack: ${RACK_ENV_VAR}
+
+# For information on supported formats and syntax for the config file, see
+# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/setup-configuration.html>
+
+
+################################### Cluster ###################################
+
+# Cluster name identifies your cluster for auto-discovery. If you're running
+# multiple clusters on the same network, make sure you're using unique names.
+#
+cluster.name: opencast
+
+
+#################################### Node #####################################
+
+# Node names are generated dynamically on startup, so you're relieved
+# from configuring them manually. You can tie this node to a specific name:
+#
+#node.name: "Localhost"
+
+# Every node can be configured to allow or deny being eligible as the master,
+# and to allow or deny to store the data.
+#
+# Allow this node to be eligible as a master node (enabled by default):
+#
+#node.master: true
+#
+# Allow this node to store data (enabled by default):
+#
+#node.data: true
+
+# You can exploit these settings to design advanced cluster topologies.
+#
+# 1. You want this node to never become a master node, only to hold data.
+#    This will be the "workhorse" of your cluster.
+#
+#node.master: false
+#node.data: true
+#
+# 2. You want this node to only serve as a master: to not store any data and
+#    to have free resources. This will be the "coordinator" of your cluster.
+#
+#node.master: true
+#node.data: false
+#
+# 3. You want this node to be neither master nor data node, but
+#    to act as a "search load balancer" (fetching data from nodes,
+#    aggregating results, etc.)
+#
+#node.master: false
+#node.data: false
+
+# Use the Cluster Health API [http://localhost:9200/_cluster/health], the
+# Node Info API [http://localhost:9200/_nodes] or GUI tools
+# such as <http://www.elasticsearch.org/overview/marvel/>,
+# <http://github.com/karmi/elasticsearch-paramedic>,
+# <http://github.com/lukas-vlcek/bigdesk> and
+# <http://mobz.github.com/elasticsearch-head> to inspect the cluster state.
+
+# A node can have generic attributes associated with it, which can later be used
+# for customized shard allocation filtering, or allocation awareness. An attribute
+# is a simple key value pair, similar to node.key: value, here is an example:
+#
+#node.rack: rack314
+
+# By default, multiple nodes are allowed to start from the same installation location
+# to disable it, set the following:
+#node.max_local_storage_nodes: 1
+
+
+#################################### Index ####################################
+
+# You can set a number of options (such as shard/replica options, mapping
+# or analyzer definitions, translog settings, ...) for indices globally,
+# in this file.
+#
+# Note, that it makes more sense to configure index settings specifically for
+# a certain index, either when creating it or by using the index templates API.
+#
+# See <http://elasticsearch.org/guide/en/elasticsearch/reference/current/index-modules.html> and
+# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/indices-create-index.html>
+# for more information.
+
+# Set the number of shards (splits) of an index (5 by default):
+#
+index.number_of_shards: 1
+
+# Set the number of replicas (additional copies) of an index (1 by default):
+#
+index.number_of_replicas: 0
+
+# Note, that for development on a local machine, with small indices, it usually
+# makes sense to "disable" the distributed features:
+#
+#index.number_of_shards: 1
+#index.number_of_replicas: 0
+
+# These settings directly affect the performance of index and search operations
+# in your cluster. Assuming you have enough machines to hold shards and
+# replicas, the rule of thumb is:
+#
+# 1. Having more *shards* enhances the _indexing_ performance and allows to
+#    _distribute_ a big index across machines.
+# 2. Having more *replicas* enhances the _search_ performance and improves the
+#    cluster _availability_.
+#
+# The "number_of_shards" is a one-time setting for an index.
+#
+# The "number_of_replicas" can be increased or decreased anytime,
+# by using the Index Update Settings API.
+#
+# Elasticsearch takes care about load balancing, relocating, gathering the
+# results from nodes, etc. Experiment with different settings to fine-tune
+# your setup.
+
+# Use the Index Status API (<http://localhost:9200/A/_status>) to inspect
+# the index status.
+
+
+#################################### Paths ####################################
+
+# Path to directory containing configuration (this file and logging.yml):
+#
+path.conf: ${karaf.etc}/index/externalapi
+
+# Path to directory where to store index data allocated for this node.
+#
+#path.data: /path/to/data
+#
+# Can optionally include more than one location, causing data to be striped across
+# the locations (a la RAID 0) on a file level, favouring locations with most free
+# space on creation. For example:
+#
+path.data: /data/index/data
+
+# Path to temporary files:
+#
+path.work: /data/index/externalapi
+
+# Path to log files:
+#
+path.logs: /data/log/elasticsearch.log
+
+# Path to where plugins are installed:
+#
+#path.plugins: /path/to/plugins
+
+
+#################################### Plugin ###################################
+
+# If a plugin listed here is not installed for current node, the node will not start.
+#
+#plugin.mandatory: mapper-attachments,lang-groovy
+
+
+################################### Memory ####################################
+
+# Elasticsearch performs poorly when JVM starts swapping: you should ensure that
+# it _never_ swaps.
+#
+# Set this property to true to lock the memory:
+#
+#bootstrap.mlockall: true
+
+# Make sure that the ES_MIN_MEM and ES_MAX_MEM environment variables are set
+# to the same value, and that the machine has enough memory to allocate
+# for Elasticsearch, leaving enough memory for the operating system itself.
+#
+# You should also make sure that the Elasticsearch process is allowed to lock
+# the memory, eg. by using `ulimit -l unlimited`.
+
+
+############################## Network And HTTP ###############################
+
+# Elasticsearch, by default, binds itself to the 0.0.0.0 address, and listens
+# on port [9200-9300] for HTTP traffic and on port [9300-9400] for node-to-node
+# communication. (the range means that if the port is busy, it will automatically
+# try the next port).
+
+# Set the bind address specifically (IPv4 or IPv6):
+#
+#network.bind_host: 192.168.0.1
+
+# Set the address other nodes will use to communicate with this node. If not
+# set, it is automatically derived. It must point to an actual IP address.
+#
+#network.publish_host: 192.168.0.1
+
+# Set both 'bind_host' and 'publish_host':
+#
+network.host: 127.0.0.1
+
+# Set a custom port for the node to node communication (9300 by default):
+#
+#transport.tcp.port: 9300
+
+# Enable compression for all communication between nodes (disabled by default):
+#
+#transport.tcp.compress: true
+
+# Set a custom port to listen for HTTP traffic:
+#
+#http.port: 9200
+
+# Set a custom allowed content length:
+#
+#http.max_content_length: 100mb
+
+# Disable HTTP completely:
+#
+#http.enabled: false
+
+
+################################### Gateway ###################################
+
+# The gateway allows for persisting the cluster state between full cluster
+# restarts. Every change to the state (such as adding an index) will be stored
+# in the gateway, and when the cluster starts up for the first time,
+# it will read its state from the gateway.
+
+# There are several types of gateway implementations. For more information, see
+# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/modules-gateway.html>.
+
+# The default gateway type is the "local" gateway (recommended):
+#
+#gateway.type: local
+
+# Settings below control how and when to start the initial recovery process on
+# a full cluster restart (to reuse as much local data as possible when using shared
+# gateway).
+
+# Allow recovery process after N nodes in a cluster are up:
+#
+#gateway.recover_after_nodes: 1
+
+# Set the timeout to initiate the recovery process, once the N nodes
+# from previous setting are up (accepts time value):
+#
+#gateway.recover_after_time: 5m
+
+# Set how many nodes are expected in this cluster. Once these N nodes
+# are up (and recover_after_nodes is met), begin recovery process immediately
+# (without waiting for recover_after_time to expire):
+#
+#gateway.expected_nodes: 2
+
+
+############################# Recovery Throttling #############################
+
+# These settings allow to control the process of shards allocation between
+# nodes during initial recovery, replica allocation, rebalancing,
+# or when adding and removing nodes.
+
+# Set the number of concurrent recoveries happening on a node:
+#
+# 1. During the initial recovery
+#
+#cluster.routing.allocation.node_initial_primaries_recoveries: 4
+#
+# 2. During adding/removing nodes, rebalancing, etc
+#
+#cluster.routing.allocation.node_concurrent_recoveries: 2
+
+# Set to throttle throughput when recovering (eg. 100mb, by default 20mb):
+#
+#indices.recovery.max_bytes_per_sec: 20mb
+
+# Set to limit the number of open concurrent streams when
+# recovering a shard from a peer:
+#
+#indices.recovery.concurrent_streams: 5
+
+
+################################## Discovery ##################################
+
+# Discovery infrastructure ensures nodes can be found within a cluster
+# and master node is elected. Multicast discovery is the default.
+
+# Set to ensure a node sees N other master eligible nodes to be considered
+# operational within the cluster. Its recommended to set it to a higher value
+# than 1 when running more than 2 nodes in the cluster.
+#
+#discovery.zen.minimum_master_nodes: 1
+
+# Set the time to wait for ping responses from other nodes when discovering.
+# Set this option to a higher value on a slow or congested network
+# to minimize discovery failures:
+#
+#discovery.zen.ping.timeout: 3s
+
+# For more information, see
+# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/modules-discovery-zen.html>
+
+# Unicast discovery allows to explicitly control which nodes will be used
+# to discover the cluster. It can be used when multicast is not present,
+# or to restrict the cluster communication-wise.
+#
+# 1. Disable multicast discovery (enabled by default):
+#
+#discovery.zen.ping.multicast.enabled: false
+#
+# 2. Configure an initial list of master nodes in the cluster
+#    to perform discovery when new nodes (master or data) are started:
+#
+#discovery.zen.ping.unicast.hosts: ["host1", "host2:port"]
+
+# EC2 discovery allows to use AWS EC2 API in order to perform discovery.
+#
+# You have to install the cloud-aws plugin for enabling the EC2 discovery.
+#
+# For more information, see
+# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/modules-discovery-ec2.html>
+#
+# See <http://elasticsearch.org/tutorials/elasticsearch-on-ec2/>
+# for a step-by-step tutorial.
+
+# GCE discovery allows to use Google Compute Engine API in order to perform discovery.
+#
+# You have to install the cloud-gce plugin for enabling the GCE discovery.
+#
+# For more information, see <https://github.com/elasticsearch/elasticsearch-cloud-gce>.
+
+# Azure discovery allows to use Azure API in order to perform discovery.
+#
+# You have to install the cloud-azure plugin for enabling the Azure discovery.
+#
+# For more information, see <https://github.com/elasticsearch/elasticsearch-cloud-azure>.
+
+################################## Slow Log ##################################
+
+# Shard level query and fetch threshold logging.
+
+#index.search.slowlog.threshold.query.warn: 10s
+#index.search.slowlog.threshold.query.info: 5s
+#index.search.slowlog.threshold.query.debug: 2s
+#index.search.slowlog.threshold.query.trace: 500ms
+
+#index.search.slowlog.threshold.fetch.warn: 1s
+#index.search.slowlog.threshold.fetch.info: 800ms
+#index.search.slowlog.threshold.fetch.debug: 500ms
+#index.search.slowlog.threshold.fetch.trace: 200ms
+
+#index.indexing.slowlog.threshold.index.warn: 10s
+#index.indexing.slowlog.threshold.index.info: 5s
+#index.indexing.slowlog.threshold.index.debug: 2s
+#index.indexing.slowlog.threshold.index.trace: 500ms
+
+################################## GC Logging ################################
+
+#monitor.jvm.gc.young.warn: 1000ms
+#monitor.jvm.gc.young.info: 700ms
+#monitor.jvm.gc.young.debug: 400ms
+
+#monitor.jvm.gc.old.warn: 10s
+#monitor.jvm.gc.old.info: 5s
+#monitor.jvm.gc.old.debug: 2s
+
+################################## Security ###################################
+
+# Uncomment if you want to enable JSONP as a valid return transport on the
+# http server. With this enabled, it may pose a security risk, so disabling
+# it unless you need it is recommended (it is disabled by default).
+#
+#http.jsonp.enable: true
+
+
+################################## Shutdown ###################################
+
+# Disable the Elasticsearch Shutdown API (recomended).
+action.disable_shutdown: true

--- a/Dockerfiles/build/assets/build/etc/develop/org.opencastproject.ingest.scanner.InboxScannerService-inbox.cfg
+++ b/Dockerfiles/build/assets/build/etc/develop/org.opencastproject.ingest.scanner.InboxScannerService-inbox.cfg
@@ -1,0 +1,22 @@
+# Specify user to use when ingesting media from the inbox
+user.name=admin
+user.organization=mh_default_org
+
+# Specify the workflow definition (by its identifier) to run for media, ingested from the inbox
+workflow.definition=ng-schedule-and-upload
+
+# Specify flavor to use for ingested media files. This configuration has no effect on zipped mediapackages since they
+# contain the flavor information in their manifest xml file.
+media.flavor=presentation/source
+
+# Specify the workflow configuration
+# Example:
+#   workflow.config.{key}={value}
+workflow.config.flagForReview=true
+workflow.config.straightToPublishing=false
+
+# Path to the Inbox directory
+inbox.path=/data/inbox
+
+# Inbox polling interval in ms.
+inbox.poll=5000

--- a/Dockerfiles/build/assets/build/etc/develop/org.ops4j.pax.logging.cfg
+++ b/Dockerfiles/build/assets/build/etc/develop/org.ops4j.pax.logging.cfg
@@ -1,0 +1,30 @@
+# Root logger configuration.  This defines the default values to be used.  They may be overwritten by more specific
+# settings below.
+log4j.rootLogger=WARN, out, osgi:*
+log4j.throwableRenderer=org.apache.log4j.OsgiThrowableRenderer
+
+# Loglevel configuration for all opencast modules. Usually, INFO is a quite sane log level. If you need a different
+# detail level of logs, you can adjust this to: ERROR, WARN, INFO, DEBUG, TRACE.
+log4j.logger.org.opencastproject=DEBUG
+
+# You can specify different log levels for different packages/modules by specifying their package component names. For
+# example, to raise the log level to DEBUG for the rest endpoints contained in the kernel module, set:
+# log4j.logger.org.opencastproject.kernel.rest=DEBUG
+
+# For Karaf, Felix & CXF, we want to see some more details in the logs
+log4j.logger.org.apache.karaf=WARN
+log4j.logger.org.apache.felix=WARN
+log4j.logger.org.apache.cxf=WARN
+
+# Console appender not used by default
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} | %-5.5p | (%C{1}:%L) - %m%n
+
+# File appender
+log4j.appender.out=org.apache.log4j.FileAppender
+log4j.appender.out.layout=org.apache.log4j.PatternLayout
+log4j.appender.out.layout.ConversionPattern=%d{ISO8601} | %-5.5p | (%C{1}:%L) - %m%n
+log4j.appender.out.file=${karaf.data}/log/opencast.log
+log4j.appender.out.append=true
+log4j.appender.out.encoding=UTF-8

--- a/Dockerfiles/build/assets/build/etc/develop/org.ops4j.pax.web.cfg
+++ b/Dockerfiles/build/assets/build/etc/develop/org.ops4j.pax.web.cfg
@@ -1,0 +1,43 @@
+###
+# OPS4J Pax Web Configuration
+##
+
+# See https://ops4j1.jira.com/wiki/display/paxweb/Basic+Configuration for more details
+
+
+# This property specifies the comma separated list of addresses used by Opencast to listen to (e.g. localhost or
+# localhost,10.0.0.1). Host names or IP addresses can be used. Pax Web default value is "0.0.0.0".
+org.ops4j.pax.web.listening.addresses=0.0.0.0
+
+# The HTTP server port.
+# You may want to keep this on port 8080 but add an HTTP server like the Apache httpd or Nginx as reverse proxy so that
+# users can access Opencast using port 80 (HTTP default).
+org.osgi.service.http.port=8080
+
+# This property specifies if the HTTP is enabled. If "true" the support for HTTP access will be enabled. If "false" the
+# support for HTTP access will be disabled. Default value is "true".
+org.osgi.service.http.enabled=true
+
+# Whether Opencast itself should handle HTTPS traffic.
+# Even if you set this to 'false',you can still use an HTTP proxy to handle SSL.
+org.osgi.service.http.secure.enabled=false
+
+# The secure server port to use if running Opencast with HTTPS (as opposed to a proxy handling HTTPS).
+org.osgi.service.http.port.secure=8443
+
+# Path to the keystore file.
+# Use the Java `keytool` to generate this file.
+# Example:
+#   keytool -genkey -keyalg RSA -validity 365 -alias serverkey \
+#     -keypass password -storepass password -keystore keystore.jks
+org.ops4j.pax.web.ssl.keystore=${karaf.etc}/keystore.jks
+
+# Password used for keystore integrity check.
+org.ops4j.pax.web.ssl.password=password
+
+# Password used for keystore.
+org.ops4j.pax.web.ssl.keypassword=password
+
+# Custom jetty config file. Uncomment this if necessary to configure the jetty http connector idleTimeout value (MH-12329)
+# Adjust the settings in the file below to match the listening address and port settings above.
+#org.ops4j.pax.web.config.file=${karaf.etc}/jetty-opencast.xml

--- a/Dockerfiles/build/assets/build/scripts/helper.sh
+++ b/Dockerfiles/build/assets/build/scripts/helper.sh
@@ -20,6 +20,10 @@ opencast_helper_dist_allinone() {
   test "${OPENCAST_DISTRIBUTION}" = "allinone"
 }
 
+opencast_helper_dist_develop() {
+  test "${OPENCAST_DISTRIBUTION}" = "develop"
+}
+
 opencast_helper_customconfig() {
   test -d "${OPENCAST_CUSTOM_CONFIG}"
 }

--- a/Dockerfiles/build/assets/build/scripts/opencast.sh
+++ b/Dockerfiles/build/assets/build/scripts/opencast.sh
@@ -20,7 +20,7 @@ ORG_OPENCASTPROJECT_SERVER_URL="${ORG_OPENCASTPROJECT_SERVER_URL:-http://$(hostn
 ORG_OPENCASTPROJECT_ADMIN_EMAIL="${ORG_OPENCASTPROJECT_ADMIN_EMAIL:-admin@localhost}"
 ORG_OPENCASTPROJECT_DOWNLOAD_URL="${ORG_OPENCASTPROJECT_DOWNLOAD_URL:-\$\{org.opencastproject.server.url\}/static}"
 
-if opencast_helper_dist_allinone; then
+if opencast_helper_dist_allinone || opencast_helper_dist_develop; then
   # shellcheck disable=SC2016
   export ORG_OPENCASTPROJECT_FILE_REPO_URL='${org.opencastproject.server.url}'
 else
@@ -38,7 +38,7 @@ opencast_opencast_check() {
     "ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS" \
     "ORG_OPENCASTPROJECT_FILE_REPO_URL"
 
-  if ! opencast_helper_dist_allinone; then
+  if ! (opencast_helper_dist_allinone || opencast_helper_dist_develop); then
     opencast_helper_checkforvariables \
       "PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL" \
       "PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL"
@@ -57,7 +57,7 @@ opencast_opencast_configure() {
     "ORG_OPENCASTPROJECT_FILE_REPO_URL" \
     "ORG_OPENCASTPROJECT_DOWNLOAD_URL"
 
-  if ! opencast_helper_dist_allinone; then
+  if ! (opencast_helper_dist_allinone || opencast_helper_dist_develop); then
     opencast_helper_replaceinfile "etc/org.opencastproject.organization-mh_default_org.cfg" \
       "PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL" \
       "PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL"

--- a/Dockerfiles/build/assets/docker-entrypoint.sh
+++ b/Dockerfiles/build/assets/docker-entrypoint.sh
@@ -20,17 +20,27 @@ set -e
 OPENCAST_BUILD_USER_UID="${OPENCAST_BUILD_USER_UID:-1000}"
 OPENCAST_BUILD_USER_GID="${OPENCAST_BUILD_USER_GID:-1000}"
 
-if ! id opencast-builder >/dev/null 2>&1; then
-  # Create a user
+SET_PERM=false
+
+# Create group
+if ! getent group "${OPENCAST_BUILD_USER_GID}" >/dev/null 2>&1; then
   groupadd -g "${OPENCAST_BUILD_USER_GID}" opencast-builder
+  SET_PERM=true
+fi
+
+# Create user
+if ! getent passwd opencast-builder >/dev/null 2>&1; then
   useradd \
     --no-user-group \
     --gid "${OPENCAST_BUILD_USER_GID}" \
     --uid "${OPENCAST_BUILD_USER_UID}" \
     opencast-builder
+  SET_PERM=true
+fi
 
-  # Make sure the user can read the Opencast source and home directory files
-  chown -R "${OPENCAST_BUILD_USER_GID}:${OPENCAST_BUILD_USER_UID}" "${OPENCAST_SRC}" /home/opencast-builder
+# Make sure the user can read the Opencast source and home directory files
+if test "${SET_PERM}" = "true"; then
+  chown -R "${OPENCAST_BUILD_USER_UID}:${OPENCAST_BUILD_USER_GID}" "${OPENCAST_SRC}" /home/opencast-builder
 fi
 
 su-exec "${OPENCAST_BUILD_USER_UID}:${OPENCAST_BUILD_USER_GID}" "$@"

--- a/Dockerfiles/ingest/assets/docker-entrypoint.sh
+++ b/Dockerfiles/ingest/assets/docker-entrypoint.sh
@@ -76,7 +76,12 @@ opencast_main_start() {
   # processes are running. We therefore can just clean up the old pid file.
   rm -rf /opencast/data/pid /opencast/instances/instance.properties
 
-  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast server &
+  if opencast_helper_dist_develop; then
+    export DEFAULT_JAVA_DEBUG_OPTS="${DEFAULT_JAVA_DEBUG_OPTS:--Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005}"
+    exec su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast debug
+  fi
+
+  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast daemon &
   OC_PID=$!
   trap opencast_main_stop TERM INT
 

--- a/Dockerfiles/ingest/assets/scripts/helper.sh
+++ b/Dockerfiles/ingest/assets/scripts/helper.sh
@@ -20,6 +20,10 @@ opencast_helper_dist_allinone() {
   test "${OPENCAST_DISTRIBUTION}" = "allinone"
 }
 
+opencast_helper_dist_develop() {
+  test "${OPENCAST_DISTRIBUTION}" = "develop"
+}
+
 opencast_helper_customconfig() {
   test -d "${OPENCAST_CUSTOM_CONFIG}"
 }

--- a/Dockerfiles/ingest/assets/scripts/opencast.sh
+++ b/Dockerfiles/ingest/assets/scripts/opencast.sh
@@ -20,7 +20,7 @@ ORG_OPENCASTPROJECT_SERVER_URL="${ORG_OPENCASTPROJECT_SERVER_URL:-http://$(hostn
 ORG_OPENCASTPROJECT_ADMIN_EMAIL="${ORG_OPENCASTPROJECT_ADMIN_EMAIL:-admin@localhost}"
 ORG_OPENCASTPROJECT_DOWNLOAD_URL="${ORG_OPENCASTPROJECT_DOWNLOAD_URL:-\$\{org.opencastproject.server.url\}/static}"
 
-if opencast_helper_dist_allinone; then
+if opencast_helper_dist_allinone || opencast_helper_dist_develop; then
   # shellcheck disable=SC2016
   export ORG_OPENCASTPROJECT_FILE_REPO_URL='${org.opencastproject.server.url}'
 else
@@ -38,7 +38,7 @@ opencast_opencast_check() {
     "ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS" \
     "ORG_OPENCASTPROJECT_FILE_REPO_URL"
 
-  if ! opencast_helper_dist_allinone; then
+  if ! (opencast_helper_dist_allinone || opencast_helper_dist_develop); then
     opencast_helper_checkforvariables \
       "PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL" \
       "PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL"
@@ -57,7 +57,7 @@ opencast_opencast_configure() {
     "ORG_OPENCASTPROJECT_FILE_REPO_URL" \
     "ORG_OPENCASTPROJECT_DOWNLOAD_URL"
 
-  if ! opencast_helper_dist_allinone; then
+  if ! (opencast_helper_dist_allinone || opencast_helper_dist_develop); then
     opencast_helper_replaceinfile "etc/org.opencastproject.organization-mh_default_org.cfg" \
       "PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL" \
       "PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL"

--- a/Dockerfiles/presentation/assets/docker-entrypoint.sh
+++ b/Dockerfiles/presentation/assets/docker-entrypoint.sh
@@ -76,7 +76,12 @@ opencast_main_start() {
   # processes are running. We therefore can just clean up the old pid file.
   rm -rf /opencast/data/pid /opencast/instances/instance.properties
 
-  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast server &
+  if opencast_helper_dist_develop; then
+    export DEFAULT_JAVA_DEBUG_OPTS="${DEFAULT_JAVA_DEBUG_OPTS:--Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005}"
+    exec su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast debug
+  fi
+
+  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast daemon &
   OC_PID=$!
   trap opencast_main_stop TERM INT
 

--- a/Dockerfiles/presentation/assets/scripts/helper.sh
+++ b/Dockerfiles/presentation/assets/scripts/helper.sh
@@ -20,6 +20,10 @@ opencast_helper_dist_allinone() {
   test "${OPENCAST_DISTRIBUTION}" = "allinone"
 }
 
+opencast_helper_dist_develop() {
+  test "${OPENCAST_DISTRIBUTION}" = "develop"
+}
+
 opencast_helper_customconfig() {
   test -d "${OPENCAST_CUSTOM_CONFIG}"
 }

--- a/Dockerfiles/presentation/assets/scripts/opencast.sh
+++ b/Dockerfiles/presentation/assets/scripts/opencast.sh
@@ -20,7 +20,7 @@ ORG_OPENCASTPROJECT_SERVER_URL="${ORG_OPENCASTPROJECT_SERVER_URL:-http://$(hostn
 ORG_OPENCASTPROJECT_ADMIN_EMAIL="${ORG_OPENCASTPROJECT_ADMIN_EMAIL:-admin@localhost}"
 ORG_OPENCASTPROJECT_DOWNLOAD_URL="${ORG_OPENCASTPROJECT_DOWNLOAD_URL:-\$\{org.opencastproject.server.url\}/static}"
 
-if opencast_helper_dist_allinone; then
+if opencast_helper_dist_allinone || opencast_helper_dist_develop; then
   # shellcheck disable=SC2016
   export ORG_OPENCASTPROJECT_FILE_REPO_URL='${org.opencastproject.server.url}'
 else
@@ -38,7 +38,7 @@ opencast_opencast_check() {
     "ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS" \
     "ORG_OPENCASTPROJECT_FILE_REPO_URL"
 
-  if ! opencast_helper_dist_allinone; then
+  if ! (opencast_helper_dist_allinone || opencast_helper_dist_develop); then
     opencast_helper_checkforvariables \
       "PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL" \
       "PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL"
@@ -57,7 +57,7 @@ opencast_opencast_configure() {
     "ORG_OPENCASTPROJECT_FILE_REPO_URL" \
     "ORG_OPENCASTPROJECT_DOWNLOAD_URL"
 
-  if ! opencast_helper_dist_allinone; then
+  if ! (opencast_helper_dist_allinone || opencast_helper_dist_develop); then
     opencast_helper_replaceinfile "etc/org.opencastproject.organization-mh_default_org.cfg" \
       "PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL" \
       "PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL"

--- a/Dockerfiles/worker/assets/docker-entrypoint.sh
+++ b/Dockerfiles/worker/assets/docker-entrypoint.sh
@@ -76,7 +76,12 @@ opencast_main_start() {
   # processes are running. We therefore can just clean up the old pid file.
   rm -rf /opencast/data/pid /opencast/instances/instance.properties
 
-  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast server &
+  if opencast_helper_dist_develop; then
+    export DEFAULT_JAVA_DEBUG_OPTS="${DEFAULT_JAVA_DEBUG_OPTS:--Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005}"
+    exec su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast debug
+  fi
+
+  su-exec "${OPENCAST_USER}":"${OPENCAST_GROUP}" bin/start-opencast daemon &
   OC_PID=$!
   trap opencast_main_stop TERM INT
 

--- a/Dockerfiles/worker/assets/scripts/helper.sh
+++ b/Dockerfiles/worker/assets/scripts/helper.sh
@@ -20,6 +20,10 @@ opencast_helper_dist_allinone() {
   test "${OPENCAST_DISTRIBUTION}" = "allinone"
 }
 
+opencast_helper_dist_develop() {
+  test "${OPENCAST_DISTRIBUTION}" = "develop"
+}
+
 opencast_helper_customconfig() {
   test -d "${OPENCAST_CUSTOM_CONFIG}"
 }

--- a/Dockerfiles/worker/assets/scripts/opencast.sh
+++ b/Dockerfiles/worker/assets/scripts/opencast.sh
@@ -20,7 +20,7 @@ ORG_OPENCASTPROJECT_SERVER_URL="${ORG_OPENCASTPROJECT_SERVER_URL:-http://$(hostn
 ORG_OPENCASTPROJECT_ADMIN_EMAIL="${ORG_OPENCASTPROJECT_ADMIN_EMAIL:-admin@localhost}"
 ORG_OPENCASTPROJECT_DOWNLOAD_URL="${ORG_OPENCASTPROJECT_DOWNLOAD_URL:-\$\{org.opencastproject.server.url\}/static}"
 
-if opencast_helper_dist_allinone; then
+if opencast_helper_dist_allinone || opencast_helper_dist_develop; then
   # shellcheck disable=SC2016
   export ORG_OPENCASTPROJECT_FILE_REPO_URL='${org.opencastproject.server.url}'
 else
@@ -38,7 +38,7 @@ opencast_opencast_check() {
     "ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS" \
     "ORG_OPENCASTPROJECT_FILE_REPO_URL"
 
-  if ! opencast_helper_dist_allinone; then
+  if ! (opencast_helper_dist_allinone || opencast_helper_dist_develop); then
     opencast_helper_checkforvariables \
       "PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL" \
       "PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL"
@@ -57,7 +57,7 @@ opencast_opencast_configure() {
     "ORG_OPENCASTPROJECT_FILE_REPO_URL" \
     "ORG_OPENCASTPROJECT_DOWNLOAD_URL"
 
-  if ! opencast_helper_dist_allinone; then
+  if ! (opencast_helper_dist_allinone || opencast_helper_dist_develop); then
     opencast_helper_replaceinfile "etc/org.opencastproject.organization-mh_default_org.cfg" \
       "PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL" \
       "PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL"

--- a/docker-compose/docker-compose.build.yml
+++ b/docker-compose/docker-compose.build.yml
@@ -40,8 +40,6 @@ services:
       - ACTIVEMQ_BROKER_URL=failover://(tcp://activemq:61616)?initialReconnectDelay=2000&maxReconnectAttempts=2
       - ACTIVEMQ_BROKER_USERNAME=admin
       - ACTIVEMQ_BROKER_PASSWORD=password
-      - KARAF_DEBUG=1
-      - DEFAULT_JAVA_DEBUG_OPTS='-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005'
     ports:
       - "8080:8080"
       - "5005:5005"

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -134,6 +134,10 @@ load test_helper
 }
 
 @test "build image should have the same distribution assets" {
+  run diff -qr "${DOCKERFILES_BUILD}/assets/build/etc/allinone" "${DOCKERFILES_BUILD}/assets/build/etc/develop" \
+           -x org.ops4j.pax.logging.cfg
+  [ "${status}" -eq 0 ]
+
   run diff -qr "${DOCKERFILES_BUILD}/assets/build/etc/allinone" "${DOCKERFILES_ALLINONE}/assets/etc"
   [ "${status}" -eq 0 ]
 


### PR DESCRIPTION
Fixes #36.

This PR adds support for the `develop` distribution by adding the ` dev` argument to the `oc_build` script. The `develop` instance is startet with debug enabled by default and also sets users into the Karaf shell instead of just displaying the logs. Feature wise it should be identical to `allinone`.