### PR TITLE
add nfs-utils package to dockerfiles to enable mounting nfs volumes i…

### DIFF
--- a/Dockerfiles/admin/Dockerfile
+++ b/Dockerfiles/admin/Dockerfile
@@ -88,7 +88,7 @@ RUN apk add --no-cache \
       openjdk8 \
       bash su-exec openssl tzdata curl jq \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
-      ffmpeg sox hunspell tesseract-ocr \
+      ffmpeg sox hunspell tesseract-ocr nfs-utils \
   \
  && javac "${OPENCAST_SCRIPTS}/TryToConnectToDb.java" \
   \

--- a/Dockerfiles/admin/Dockerfile
+++ b/Dockerfiles/admin/Dockerfile
@@ -88,7 +88,8 @@ RUN apk add --no-cache \
       openjdk8 \
       bash su-exec openssl tzdata curl jq \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
-      ffmpeg sox hunspell tesseract-ocr nfs-utils \
+      ffmpeg sox hunspell tesseract-ocr \
+      nfs-utils \
   \
  && javac "${OPENCAST_SCRIPTS}/TryToConnectToDb.java" \
   \

--- a/Dockerfiles/adminpresentation/Dockerfile
+++ b/Dockerfiles/adminpresentation/Dockerfile
@@ -88,7 +88,7 @@ RUN apk add --no-cache \
       openjdk8 \
       bash su-exec openssl tzdata curl jq \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
-      ffmpeg sox hunspell tesseract-ocr \
+      ffmpeg sox hunspell tesseract-ocr nfs-utils \
   \
  && javac "${OPENCAST_SCRIPTS}/TryToConnectToDb.java" \
   \

--- a/Dockerfiles/adminpresentation/Dockerfile
+++ b/Dockerfiles/adminpresentation/Dockerfile
@@ -88,7 +88,8 @@ RUN apk add --no-cache \
       openjdk8 \
       bash su-exec openssl tzdata curl jq \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
-      ffmpeg sox hunspell tesseract-ocr nfs-utils \
+      ffmpeg sox hunspell tesseract-ocr \
+      nfs-utils \
   \
  && javac "${OPENCAST_SCRIPTS}/TryToConnectToDb.java" \
   \

--- a/Dockerfiles/adminworker/Dockerfile
+++ b/Dockerfiles/adminworker/Dockerfile
@@ -88,7 +88,7 @@ RUN apk add --no-cache \
       openjdk8 \
       bash su-exec openssl tzdata curl jq \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
-      ffmpeg sox hunspell tesseract-ocr \
+      ffmpeg sox hunspell tesseract-ocr nfs-utils \
   \
  && javac "${OPENCAST_SCRIPTS}/TryToConnectToDb.java" \
   \

--- a/Dockerfiles/adminworker/Dockerfile
+++ b/Dockerfiles/adminworker/Dockerfile
@@ -88,7 +88,8 @@ RUN apk add --no-cache \
       openjdk8 \
       bash su-exec openssl tzdata curl jq \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
-      ffmpeg sox hunspell tesseract-ocr nfs-utils \
+      ffmpeg sox hunspell tesseract-ocr \
+      nfs-utils \
   \
  && javac "${OPENCAST_SCRIPTS}/TryToConnectToDb.java" \
   \

--- a/Dockerfiles/allinone/Dockerfile
+++ b/Dockerfiles/allinone/Dockerfile
@@ -89,6 +89,7 @@ RUN apk add --no-cache \
       bash su-exec openssl tzdata curl jq \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
       ffmpeg sox hunspell tesseract-ocr \
+      nfs-utils \
   \
  && javac "${OPENCAST_SCRIPTS}/TryToConnectToDb.java" \
   \

--- a/Dockerfiles/build/Dockerfile
+++ b/Dockerfiles/build/Dockerfile
@@ -67,6 +67,7 @@ RUN dnf -y install \
       gnu-free-serif-fonts gnu-free-mono-fonts gnu-free-sans-fonts \
       liberation-fonts linux-libertine-fonts \
       ffmpeg sox hunspell tesseract \
+      nfs-utils \
   \
  && git clone https://github.com/ncopa/su-exec.git /tmp/su-exec \
  && cd /tmp/su-exec \

--- a/Dockerfiles/ingest/Dockerfile
+++ b/Dockerfiles/ingest/Dockerfile
@@ -88,7 +88,7 @@ RUN apk add --no-cache \
       openjdk8 \
       bash su-exec openssl tzdata curl jq \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
-      ffmpeg sox hunspell tesseract-ocr \
+      ffmpeg sox hunspell tesseract-ocr nfs-utils \
   \
  && javac "${OPENCAST_SCRIPTS}/TryToConnectToDb.java" \
   \

--- a/Dockerfiles/ingest/Dockerfile
+++ b/Dockerfiles/ingest/Dockerfile
@@ -88,7 +88,8 @@ RUN apk add --no-cache \
       openjdk8 \
       bash su-exec openssl tzdata curl jq \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
-      ffmpeg sox hunspell tesseract-ocr nfs-utils \
+      ffmpeg sox hunspell tesseract-ocr \
+      nfs-utils \
   \
  && javac "${OPENCAST_SCRIPTS}/TryToConnectToDb.java" \
   \

--- a/Dockerfiles/migration/Dockerfile
+++ b/Dockerfiles/migration/Dockerfile
@@ -89,6 +89,7 @@ RUN apk add --no-cache \
       bash su-exec openssl tzdata curl jq \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
       ffmpeg sox hunspell tesseract-ocr \
+      nfs-utils \
   \
  && javac "${OPENCAST_SCRIPTS}/TryToConnectToDb.java" \
   \

--- a/Dockerfiles/presentation/Dockerfile
+++ b/Dockerfiles/presentation/Dockerfile
@@ -88,7 +88,7 @@ RUN apk add --no-cache \
       openjdk8 \
       bash su-exec openssl tzdata curl jq \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
-      ffmpeg sox hunspell tesseract-ocr \
+      ffmpeg sox hunspell tesseract-ocr nfs-utils \
   \
  && javac "${OPENCAST_SCRIPTS}/TryToConnectToDb.java" \
   \

--- a/Dockerfiles/presentation/Dockerfile
+++ b/Dockerfiles/presentation/Dockerfile
@@ -88,7 +88,8 @@ RUN apk add --no-cache \
       openjdk8 \
       bash su-exec openssl tzdata curl jq \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
-      ffmpeg sox hunspell tesseract-ocr nfs-utils \
+      ffmpeg sox hunspell tesseract-ocr \
+      nfs-utils \
   \
  && javac "${OPENCAST_SCRIPTS}/TryToConnectToDb.java" \
   \

--- a/Dockerfiles/worker/Dockerfile
+++ b/Dockerfiles/worker/Dockerfile
@@ -88,7 +88,7 @@ RUN apk add --no-cache \
       openjdk8 \
       bash su-exec openssl tzdata curl jq \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
-      ffmpeg sox hunspell tesseract-ocr \
+      ffmpeg sox hunspell tesseract-ocr nfs-utils \
   \
  && javac "${OPENCAST_SCRIPTS}/TryToConnectToDb.java" \
   \

--- a/Dockerfiles/worker/Dockerfile
+++ b/Dockerfiles/worker/Dockerfile
@@ -88,7 +88,8 @@ RUN apk add --no-cache \
       openjdk8 \
       bash su-exec openssl tzdata curl jq \
       fontconfig ttf-dejavu ttf-freefont ttf-liberation ttf-linux-libertine \
-      ffmpeg sox hunspell tesseract-ocr nfs-utils \
+      ffmpeg sox hunspell tesseract-ocr \
+      nfs-utils \
   \
  && javac "${OPENCAST_SCRIPTS}/TryToConnectToDb.java" \
   \


### PR DESCRIPTION
…n kubernetes

With the current images it's not possible to use nfs persistent volumes in kubernetes since they mount the nfs volume directly in the container. I've added the nfs-utils package and tested this in kubernetes to verify that it's now possible to use nfs volumes with these images.

I've omitted the package for the allinone image since it might be less relevant for that configuration, but can include it as well if preferred.