### PR TITLE
restores build folder permission

### DIFF
--- a/Dockerfiles/build/assets/bin/oc_install
+++ b/Dockerfiles/build/assets/bin/oc_install
@@ -36,9 +36,9 @@ log "oc_install" "Start installation"
 cd "${OPENCAST_SRC}"
 
 if test "$dist" = "develop"; then
-  log "oc_install" "Linking develop"
+  log "oc_install" "Copy develop"
   sudo rmdir "${OPENCAST_HOME}"
-  sudo ln -s /usr/src/opencast/build/opencast-dist-develop-* "${OPENCAST_HOME}"
+  sudo cp -R /usr/src/opencast/build/opencast-dist-develop-* "${OPENCAST_HOME}"
 else
   log "oc_install" "Extract archive"
   sudo tar -xzf build/opencast-dist-$dist-*.tar.gz --strip 1 -C "${OPENCAST_HOME}"

--- a/Dockerfiles/build/assets/bin/oc_install
+++ b/Dockerfiles/build/assets/bin/oc_install
@@ -38,7 +38,7 @@ cd "${OPENCAST_SRC}"
 if test "$dist" = "develop"; then
   log "oc_install" "Copy develop"
   sudo rmdir "${OPENCAST_HOME}"
-  sudo cp -R /usr/src/opencast/build/opencast-dist-develop-* "${OPENCAST_HOME}"
+  sudo cp -R build/opencast-dist-develop-* "${OPENCAST_HOME}"
 else
   log "oc_install" "Extract archive"
   sudo tar -xzf build/opencast-dist-$dist-*.tar.gz --strip 1 -C "${OPENCAST_HOME}"


### PR DESCRIPTION
The installation script (oc_install) changes the build folder permission, because the permission is not reset (oc_uninstall) building opencast will fail.

> Failed to create assembly: Error creating assembly archive bin: ../build/opencast-* is not writable.

This patch resets the build folder permission.