### PR TITLE
Truncate installation folder instead of deleting it

### DIFF
--- a/Dockerfiles/build/assets/bin/oc_install
+++ b/Dockerfiles/build/assets/bin/oc_install
@@ -37,8 +37,7 @@ cd "${OPENCAST_SRC}"
 
 if test "$dist" = "develop"; then
   log "oc_install" "Copy develop"
-  sudo rmdir "${OPENCAST_HOME}"
-  sudo cp -R build/opencast-dist-develop-* "${OPENCAST_HOME}"
+  sudo cp -R build/opencast-dist-develop-*/. "${OPENCAST_HOME}"
 else
   log "oc_install" "Extract archive"
   sudo tar -xzf build/opencast-dist-$dist-*.tar.gz --strip 1 -C "${OPENCAST_HOME}"

--- a/Dockerfiles/build/assets/bin/oc_uninstall
+++ b/Dockerfiles/build/assets/bin/oc_uninstall
@@ -18,8 +18,6 @@ set -e
 
 log "oc_uninstall" "Start uninstallation"
 
-sudo rm -rf "${OPENCAST_HOME}"
-sudo mkdir -p "${OPENCAST_HOME}"
-sudo chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_HOME}"
+sudo find "${OPENCAST_HOME:?}" -mindepth 1 -delete
 
 log "oc_uninstall" "End uninstallation"


### PR DESCRIPTION
Truncating the installation folder allows it to be mounted on the Docker host.