### PR TITLE
Add ability to pass secret environment variables by file

### DIFF
--- a/Dockerfiles/admin/assets/docker-entrypoint.sh
+++ b/Dockerfiles/admin/assets/docker-entrypoint.sh
@@ -50,9 +50,17 @@ opencast_main_configure() {
   opencast_db_configure
 }
 
+opencast_file_env() {
+  file_env ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS
+  file_env ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS
+  file_env ORG_OPENCASTPROJECT_DB_JDBC_PASS
+  file_env ACTIVEMQ_BROKER_PASSWORD
+}
+
 opencast_main_init() {
   echo "Run opencast_main_init"
 
+  opencast_file_env
   opencast_tz_set
 
   if opencast_helper_customconfig; then

--- a/Dockerfiles/adminpresentation/assets/docker-entrypoint.sh
+++ b/Dockerfiles/adminpresentation/assets/docker-entrypoint.sh
@@ -50,9 +50,17 @@ opencast_main_configure() {
   opencast_db_configure
 }
 
+opencast_file_env() {
+  file_env ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS
+  file_env ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS
+  file_env ORG_OPENCASTPROJECT_DB_JDBC_PASS
+  file_env ACTIVEMQ_BROKER_PASSWORD
+}
+
 opencast_main_init() {
   echo "Run opencast_main_init"
 
+  opencast_file_env
   opencast_tz_set
 
   if opencast_helper_customconfig; then

--- a/Dockerfiles/adminworker/assets/docker-entrypoint.sh
+++ b/Dockerfiles/adminworker/assets/docker-entrypoint.sh
@@ -50,9 +50,17 @@ opencast_main_configure() {
   opencast_db_configure
 }
 
+opencast_file_env() {
+  file_env ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS
+  file_env ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS
+  file_env ORG_OPENCASTPROJECT_DB_JDBC_PASS
+  file_env ACTIVEMQ_BROKER_PASSWORD
+}
+
 opencast_main_init() {
   echo "Run opencast_main_init"
 
+  opencast_file_env
   opencast_tz_set
 
   if opencast_helper_customconfig; then

--- a/Dockerfiles/allinone/assets/docker-entrypoint.sh
+++ b/Dockerfiles/allinone/assets/docker-entrypoint.sh
@@ -50,9 +50,17 @@ opencast_main_configure() {
   opencast_db_configure
 }
 
+opencast_file_env() {
+  file_env ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS
+  file_env ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS
+  file_env ORG_OPENCASTPROJECT_DB_JDBC_PASS
+  file_env ACTIVEMQ_BROKER_PASSWORD
+}
+
 opencast_main_init() {
   echo "Run opencast_main_init"
 
+  opencast_file_env
   opencast_tz_set
 
   if opencast_helper_customconfig; then

--- a/Dockerfiles/build/assets/build/docker-entrypoint.sh
+++ b/Dockerfiles/build/assets/build/docker-entrypoint.sh
@@ -50,9 +50,17 @@ opencast_main_configure() {
   opencast_db_configure
 }
 
+opencast_file_env() {
+  file_env ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS
+  file_env ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS
+  file_env ORG_OPENCASTPROJECT_DB_JDBC_PASS
+  file_env ACTIVEMQ_BROKER_PASSWORD
+}
+
 opencast_main_init() {
   echo "Run opencast_main_init"
 
+  opencast_file_env
   opencast_tz_set
 
   if opencast_helper_customconfig; then

--- a/Dockerfiles/ingest/assets/docker-entrypoint.sh
+++ b/Dockerfiles/ingest/assets/docker-entrypoint.sh
@@ -50,9 +50,17 @@ opencast_main_configure() {
   opencast_db_configure
 }
 
+opencast_file_env() {
+  file_env ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS
+  file_env ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS
+  file_env ORG_OPENCASTPROJECT_DB_JDBC_PASS
+  file_env ACTIVEMQ_BROKER_PASSWORD
+}
+
 opencast_main_init() {
   echo "Run opencast_main_init"
 
+  opencast_file_env
   opencast_tz_set
 
   if opencast_helper_customconfig; then

--- a/Dockerfiles/migration/assets/docker-entrypoint.sh
+++ b/Dockerfiles/migration/assets/docker-entrypoint.sh
@@ -50,9 +50,17 @@ opencast_main_configure() {
   opencast_db_configure
 }
 
+opencast_file_env() {
+  file_env ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS
+  file_env ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS
+  file_env ORG_OPENCASTPROJECT_DB_JDBC_PASS
+  file_env ACTIVEMQ_BROKER_PASSWORD
+}
+
 opencast_main_init() {
   echo "Run opencast_main_init"
 
+  opencast_file_env
   opencast_tz_set
 
   if opencast_helper_customconfig; then

--- a/Dockerfiles/presentation/assets/docker-entrypoint.sh
+++ b/Dockerfiles/presentation/assets/docker-entrypoint.sh
@@ -50,9 +50,17 @@ opencast_main_configure() {
   opencast_db_configure
 }
 
+opencast_file_env() {
+  file_env ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS
+  file_env ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS
+  file_env ORG_OPENCASTPROJECT_DB_JDBC_PASS
+  file_env ACTIVEMQ_BROKER_PASSWORD
+}
+
 opencast_main_init() {
   echo "Run opencast_main_init"
 
+  opencast_file_env
   opencast_tz_set
 
   if opencast_helper_customconfig; then

--- a/Dockerfiles/worker/assets/docker-entrypoint.sh
+++ b/Dockerfiles/worker/assets/docker-entrypoint.sh
@@ -50,9 +50,17 @@ opencast_main_configure() {
   opencast_db_configure
 }
 
+opencast_file_env() {
+  file_env ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS
+  file_env ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS
+  file_env ORG_OPENCASTPROJECT_DB_JDBC_PASS
+  file_env ACTIVEMQ_BROKER_PASSWORD
+}
+
 opencast_main_init() {
   echo "Run opencast_main_init"
 
+  opencast_file_env
   opencast_tz_set
 
   if opencast_helper_customconfig; then

--- a/README.md
+++ b/README.md
@@ -138,11 +138,11 @@ Make sure to use the correct Opencast distribution as there are small difference
 -   `ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER` **Required**<br>
     Username of the admin user.
 -   `ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS` **Required**<br>
-    Password of the admin user.
+    Password of the admin user. You may alternatively set `ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS_FILE` to the location of a file within the container that contains the password.
 -   `ORG_OPENCASTPROJECT_SECURITY_DIGEST_USER` **Required**<br>
     Username for the communication between Opencast nodes and capture agents.
 -   `ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS` **Required**<br>
-    Password for the communication between Opencast nodes and capture agents.
+    Password for the communication between Opencast nodes and capture agents. You may alternatively set `ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS_FILE` to the location of a file within the container that contains the password.
 -   `ORG_OPENCASTPROJECT_DOWNLOAD_URL` Optional<br>
     The HTTP-URL to use for downloading media files, e.g. for the player. Defaults to `${org.opencastproject.server.url}/static`.
 -   `ORG_OPENCASTPROJECT_ADMIN_EMAIL` Optional<br>
@@ -169,7 +169,7 @@ The `migration` distribution has the following additional options:
 -   `ACTIVEMQ_BROKER_USERNAME` **Required**<br>
     ActiveMQ username.
 -   `ACTIVEMQ_BROKER_PASSWORD` **Required**<br>
-    Password of the ActiveMQ user.
+    Password of the ActiveMQ user. You may alternatively set `ACTIVEMQ_BROKER_PASSWORD_FILE` to the location of a file within the container that contains the password.
 
 ## Database
 
@@ -191,7 +191,7 @@ There are no additional environment variables you can set if you are using the H
 -   `ORG_OPENCASTPROJECT_DB_JDBC_USER` **Required**<br>
     Database username.
 -   `ORG_OPENCASTPROJECT_DB_JDBC_PASS` **Required**<br>
-    Password of the database user.
+    Password of the database user. You may alternatively set `ORG_OPENCASTPROJECT_DB_JDBC_PASS_FILE` to the location of a file within the container that contains the password.
 
 ## Miscellaneous
 


### PR DESCRIPTION
Adds a `<var_FILE>` variant for these variables:
```
ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS
ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS
ORG_OPENCASTPROJECT_DB_JDBC_PASS
ACTIVEMQ_BROKER_PASSWORD
```
This allows to set sensitive environment variables indirect by the contents of a file.

Fixes #98