### PR TITLE
Improve of docker-compose multisrv

### DIFF
--- a/docker-compose/assets/opencast-ddl.sql
+++ b/docker-compose/assets/opencast-ddl.sql
@@ -1,3 +1,5 @@
+-- Created with Opencast version next
+
 CREATE TABLE SEQUENCE (
   SEQ_NAME VARCHAR(50) NOT NULL,
   SEQ_COUNT DECIMAL(38),

--- a/docker-compose/assets/opencast-ddl.sql
+++ b/docker-compose/assets/opencast-ddl.sql
@@ -1,5 +1,3 @@
--- Created with Opencast version next
-
 CREATE TABLE SEQUENCE (
   SEQ_NAME VARCHAR(50) NOT NULL,
   SEQ_COUNT DECIMAL(38),
@@ -156,7 +154,6 @@ CREATE TABLE oc_job (
   parent BIGINT,
   root BIGINT,
   job_load FLOAT NOT NULL DEFAULT 1.0,
-  blocking_job BIGINT DEFAULT NULL,
   PRIMARY KEY (id),
   CONSTRAINT FK_oc_job_creator_service FOREIGN KEY (creator_service) REFERENCES oc_service_registration (id) ON DELETE CASCADE,
   CONSTRAINT FK_oc_job_processor_service FOREIGN KEY (processor_service) REFERENCES oc_service_registration (id) ON DELETE CASCADE,
@@ -184,13 +181,6 @@ CREATE TABLE oc_job_argument (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE INDEX IX_oc_job_argument_id ON oc_job_argument (id);
-
-CREATE TABLE oc_blocking_job (
-  id BIGINT NOT NULL,
-  blocking_job_list BIGINT,
-  job_index INTEGER,
-  CONSTRAINT FK_oc_blocking_job_id FOREIGN KEY (id) REFERENCES oc_job (id) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE oc_job_context (
   id BIGINT NOT NULL,
@@ -244,21 +234,24 @@ CREATE INDEX IX_oc_scheduled_last_modified_last_modified ON oc_scheduled_last_mo
 CREATE TABLE oc_scheduled_extended_event (
   mediapackage_id VARCHAR(128) NOT NULL,
   organization VARCHAR(128) NOT NULL,
+  capture_agent_id VARCHAR(128) NOT NULL,
+  start_date DATETIME NOT NULL,
+  end_date DATETIME NOT NULL,
+  source VARCHAR(255),
+  recording_state VARCHAR(255),
+  recording_last_heard BIGINT,
+  presenters TEXT(65535),
+  last_modified_date DATETIME,
+  checksum VARCHAR(64),
+  capture_agent_properties MEDIUMTEXT,
+  workflow_properties MEDIUMTEXT,
   PRIMARY KEY (mediapackage_id, organization),
   CONSTRAINT FK_oc_scheduled_extended_event_organization FOREIGN KEY (organization) REFERENCES oc_organization (id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-CREATE TABLE oc_scheduled_transaction (
-  id VARCHAR(128) NOT NULL,
-  organization VARCHAR(128) NOT NULL,
-  source VARCHAR(255) NOT NULL,
-  last_modified DATETIME NOT NULL,
-  PRIMARY KEY (id, organization),
-  CONSTRAINT UNQ_oc_scheduled_transaction UNIQUE (id, organization, source),
-  CONSTRAINT FK_oc_scheduled_transaction_organization FOREIGN KEY (organization) REFERENCES oc_organization (id) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-CREATE INDEX IX_oc_scheduled_transaction_source ON oc_scheduled_transaction (source);
+CREATE INDEX IX_oc_scheduled_extended_event_organization ON oc_scheduled_extended_event (organization);
+CREATE INDEX IX_oc_scheduled_extended_event_capture_agent_id ON oc_scheduled_extended_event (capture_agent_id);
+CREATE INDEX IX_oc_scheduled_extended_event_dates ON oc_scheduled_extended_event (start_date, end_date);
 
 CREATE TABLE oc_search (
   id VARCHAR(128) NOT NULL,
@@ -269,6 +262,7 @@ CREATE TABLE oc_search (
   mediapackage_xml MEDIUMTEXT,
   modification_date DATETIME,
   PRIMARY KEY (id),
+  KEY `IX_oc_search_series` (`series_id`),
   CONSTRAINT FK_oc_search_organization FOREIGN KEY (organization) REFERENCES oc_organization (id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -279,7 +273,6 @@ CREATE TABLE oc_series (
   organization VARCHAR(128) NOT NULL,
   access_control TEXT(65535),
   dublin_core TEXT(65535),
-  opt_out   tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (id, organization),
   CONSTRAINT FK_oc_series_organization FOREIGN KEY (organization) REFERENCES oc_organization (id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -374,7 +367,8 @@ CREATE TABLE oc_assets_snapshot (
   INDEX IX_oc_assets_snapshot_archival_date (archival_date),
   INDEX IX_oc_assets_snapshot_mediapackage_id (mediapackage_id),
   INDEX IX_oc_assets_snapshot_organization_id (organization_id),
-  INDEX IX_oc_assets_snapshot_owner (owner)
+  INDEX IX_oc_assets_snapshot_owner (owner),
+  INDEX IX_oc_assets_snapshot_series (series_id, version)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE oc_assets_asset (
@@ -388,7 +382,8 @@ CREATE TABLE oc_assets_asset (
   --
   CONSTRAINT FK_oc_assets_asset_snapshot_id FOREIGN KEY (snapshot_id) REFERENCES oc_assets_snapshot (id) ON DELETE CASCADE,
   INDEX IX_oc_assets_asset_checksum (checksum),
-  INDEX IX_oc_assets_asset_mediapackage_element_id (mediapackage_element_id)
+  INDEX IX_oc_assets_asset_mediapackage_element_id (mediapackage_element_id),
+  INDEX IX_oc_assets_asset_snapshot_id (snapshot_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE oc_assets_properties (
@@ -425,35 +420,6 @@ CREATE TABLE oc_acl_managed_acl (
   organization_id VARCHAR(128) NOT NULL,
   PRIMARY KEY (pk),
   CONSTRAINT UNQ_oc_acl_managed_acl UNIQUE (name, organization_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-CREATE TABLE oc_acl_episode_transition (
-  pk BIGINT(20) NOT NULL,
-  workflow_params VARCHAR(255) DEFAULT NULL,
-  application_date DATETIME DEFAULT NULL,
-  workflow_id VARCHAR(128) DEFAULT NULL,
-  done TINYINT(1) DEFAULT 0,
-  episode_id VARCHAR(128) DEFAULT NULL,
-  organization_id VARCHAR(128) DEFAULT NULL,
-  managed_acl_fk BIGINT(20) DEFAULT NULL,
-  PRIMARY KEY (pk),
-  CONSTRAINT UNQ_oc_acl_episode_transition UNIQUE (episode_id, organization_id, application_date),
-  CONSTRAINT FK_oc_acl_episode_transition_managed_acl_fk FOREIGN KEY (managed_acl_fk) REFERENCES oc_acl_managed_acl (pk)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-CREATE TABLE oc_acl_series_transition (
-  pk BIGINT(20) NOT NULL,
-  workflow_params VARCHAR(255) DEFAULT NULL,
-  application_date DATETIME DEFAULT NULL,
-  workflow_id VARCHAR(128) DEFAULT NULL,
-  override TINYINT(1) DEFAULT 0,
-  done TINYINT(1) DEFAULT 0,
-  organization_id VARCHAR(128) DEFAULT NULL,
-  series_id VARCHAR(128) DEFAULT NULL,
-  managed_acl_fk BIGINT(20) DEFAULT NULL,
-  PRIMARY KEY (pk),
-  CONSTRAINT UNQ_oc_acl_series_transition UNIQUE (series_id, organization_id, application_date),
-  CONSTRAINT FK_oc_acl_series_transition_managed_acl_fk FOREIGN KEY (managed_acl_fk) REFERENCES oc_acl_managed_acl (pk)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE oc_role (
@@ -549,59 +515,6 @@ CREATE TABLE oc_user_settings (
 
 CREATE INDEX IX_oc_user_setting_organization ON oc_user_settings (organization);
 
-CREATE TABLE oc_email_configuration (
-  id BIGINT(20) NOT NULL,
-  organization VARCHAR(128) NOT NULL,
-  port INT(5) DEFAULT NULL,
-  transport VARCHAR(255) DEFAULT NULL,
-  username VARCHAR(255) DEFAULT NULL,
-  server VARCHAR(255) NOT NULL,
-  ssl_enabled TINYINT(1) NOT NULL DEFAULT '0',
-  password VARCHAR(255) DEFAULT NULL,
-  PRIMARY KEY (id),
-  CONSTRAINT UNQ_oc_email_configuration UNIQUE (organization),
-  CONSTRAINT FK_oc_email_configuration_organization FOREIGN KEY (organization) REFERENCES oc_organization (id) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-CREATE INDEX IX_oc_email_configuration_organization ON oc_email_configuration (organization);
-
-CREATE TABLE oc_message_signature (
-  id BIGINT(20) NOT NULL,
-  organization VARCHAR(128) NOT NULL,
-  name VARCHAR(255) NOT NULL,
-  creation_date DATETIME NOT NULL,
-  sender VARCHAR(255) NOT NULL,
-  sender_name VARCHAR(255) NOT NULL,
-  reply_to VARCHAR(255) DEFAULT NULL,
-  reply_to_name VARCHAR(255) DEFAULT NULL,
-  signature VARCHAR(255) NOT NULL,
-  creator_username VARCHAR(255) NOT NULL,
-  PRIMARY KEY (id),
-  CONSTRAINT UNQ_oc_message_signature UNIQUE (organization, name),
-  CONSTRAINT FK_oc_message_signature_organization FOREIGN KEY (organization) REFERENCES oc_organization (id) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-CREATE INDEX IX_oc_message_signature_organization ON oc_message_signature (organization);
-CREATE INDEX IX_oc_message_signature_name ON oc_message_signature (name);
-
-CREATE TABLE oc_message_template (
-  id BIGINT(20) NOT NULL,
-  organization VARCHAR(128) NOT NULL,
-  body TEXT(65535) NOT NULL,
-  creation_date DATETIME NOT NULL,
-  subject VARCHAR(255) NOT NULL,
-  name VARCHAR(255) NOT NULL,
-  template_type VARCHAR(255) DEFAULT NULL,
-  creator_username VARCHAR(255) NOT NULL,
-  hidden TINYINT(1) NOT NULL DEFAULT '0',
-  PRIMARY KEY (id),
-  CONSTRAINT UNQ_oc_message_template UNIQUE (organization, name),
-  CONSTRAINT FK_oc_message_template_organization FOREIGN KEY (organization) REFERENCES oc_organization (id) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-CREATE INDEX IX_oc_message_template_organization ON oc_message_template (organization);
-CREATE INDEX IX_oc_message_template_name ON oc_message_template (name);
-
 CREATE TABLE oc_event_comment (
   id BIGINT(20) NOT NULL,
   organization VARCHAR(128) NOT NULL,
@@ -612,7 +525,8 @@ CREATE TABLE oc_event_comment (
   reason VARCHAR(255) DEFAULT NULL,
   modification_date DATETIME NOT NULL,
   resolved_status TINYINT(1) NOT NULL DEFAULT '0',
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
+  KEY IX_oc_event_comment_event (event, organization)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE oc_event_comment_reply (

--- a/docker-compose/docker-compose.multiserver.mariadb.yml
+++ b/docker-compose/docker-compose.multiserver.mariadb.yml
@@ -63,9 +63,6 @@ services:
       - ACTIVEMQ_BROKER_PASSWORD=password
     ports:
       - "8080:8080"
-    depends_on:
-      - mariadb
-      - activemq
     volumes:
       - data:/data
 
@@ -89,9 +86,6 @@ services:
       - ACTIVEMQ_BROKER_PASSWORD=password
     ports:
       - "8081:8080"
-    depends_on:
-      - mariadb
-      - activemq
     volumes:
       - data:/data
 

--- a/docker-compose/docker-compose.multiserver.mariadb.yml
+++ b/docker-compose/docker-compose.multiserver.mariadb.yml
@@ -113,11 +113,5 @@ services:
       - ACTIVEMQ_BROKER_URL=failover://(tcp://activemq:61616)?initialReconnectDelay=2000&maxReconnectDelay=60000
       - ACTIVEMQ_BROKER_USERNAME=admin
       - ACTIVEMQ_BROKER_PASSWORD=password
-    depends_on:
-      - mariadb
-      - activemq
     volumes:
       - data:/data
-    
-
-    

--- a/docker-compose/docker-compose.multiserver.mariadb.yml
+++ b/docker-compose/docker-compose.multiserver.mariadb.yml
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 version: "3"
+
 volumes:
   data: {}
   db: {}
+  assets:
 services:
   mariadb:
     image: mariadb:10.0
@@ -24,11 +26,16 @@ services:
       - MYSQL_DATABASE=opencast
       - MYSQL_USER=opencast
       - MYSQL_PASSWORD=opencast
-    ports:
-      - "3306:3306"
     volumes:
       - ./assets/opencast-ddl.sql:/docker-entrypoint-initdb.d/opencast-ddl.sql:ro
       - db:/var/lib/mysql
+    command: [
+            '--wait_timeout=28800',
+        ]
+    networks:
+      default:
+        aliases:
+          - mariadb
 
   activemq:
     image: webcenter/activemq:5.14.3
@@ -41,6 +48,10 @@ services:
       - ACTIVEMQ_OWNER_PASSWORD=password
     volumes:
       - ./assets/activemq.xml:/opt/activemq/conf/activemq.xml:ro
+    networks:
+      default:
+        aliases:
+          - activemq
 
   opencast-admin:
     image: quay.io/opencast/admin:next
@@ -62,8 +73,15 @@ services:
       - ACTIVEMQ_BROKER_PASSWORD=password
     ports:
       - "8080:8080"
+    depends_on:
+      - mariadb
+      - activemq
     volumes:
-      - data:/data
+      - ./data:/data
+    networks:
+      default:
+        aliases:
+          - opencast-admin
 
   opencast-presentation:
     image: quay.io/opencast/presentation:next
@@ -85,8 +103,15 @@ services:
       - ACTIVEMQ_BROKER_PASSWORD=password
     ports:
       - "8081:8080"
+    depends_on:
+      - mariadb
+      - activemq
     volumes:
-      - data:/data
+      - ./data:/data
+    networks:
+      default:
+        aliases:
+          - opencast-presentation
 
   opencast-worker:
     image: quay.io/opencast/worker:next
@@ -106,5 +131,13 @@ services:
       - ACTIVEMQ_BROKER_URL=failover://(tcp://activemq:61616)?initialReconnectDelay=2000&maxReconnectDelay=60000
       - ACTIVEMQ_BROKER_USERNAME=admin
       - ACTIVEMQ_BROKER_PASSWORD=password
+    depends_on:
+      - mariadb
+      - activemq
     volumes:
-      - data:/data
+      - ./data:/data-
+    networks:
+      default:
+        aliases:
+          - opencast-worker
+    

--- a/docker-compose/docker-compose.multiserver.mariadb.yml
+++ b/docker-compose/docker-compose.multiserver.mariadb.yml
@@ -17,8 +17,8 @@ version: "3"
 volumes:
   data: {}
   db: {}
-  assets:
-services:
+
+services:  
   mariadb:
     image: mariadb:10.0
     environment:
@@ -26,16 +26,10 @@ services:
       - MYSQL_DATABASE=opencast
       - MYSQL_USER=opencast
       - MYSQL_PASSWORD=opencast
+    command: '--wait_timeout=28800'
     volumes:
       - ./assets/opencast-ddl.sql:/docker-entrypoint-initdb.d/opencast-ddl.sql:ro
       - db:/var/lib/mysql
-    command: [
-            '--wait_timeout=28800',
-        ]
-    networks:
-      default:
-        aliases:
-          - mariadb
 
   activemq:
     image: webcenter/activemq:5.14.3
@@ -48,10 +42,6 @@ services:
       - ACTIVEMQ_OWNER_PASSWORD=password
     volumes:
       - ./assets/activemq.xml:/opt/activemq/conf/activemq.xml:ro
-    networks:
-      default:
-        aliases:
-          - activemq
 
   opencast-admin:
     image: quay.io/opencast/admin:next
@@ -77,11 +67,7 @@ services:
       - mariadb
       - activemq
     volumes:
-      - ./data:/data
-    networks:
-      default:
-        aliases:
-          - opencast-admin
+      - data:/data
 
   opencast-presentation:
     image: quay.io/opencast/presentation:next
@@ -107,11 +93,7 @@ services:
       - mariadb
       - activemq
     volumes:
-      - ./data:/data
-    networks:
-      default:
-        aliases:
-          - opencast-presentation
+      - data:/data
 
   opencast-worker:
     image: quay.io/opencast/worker:next
@@ -135,9 +117,7 @@ services:
       - mariadb
       - activemq
     volumes:
-      - ./data:/data-
-    networks:
-      default:
-        aliases:
-          - opencast-worker
+      - data:/data
+    
+
     


### PR DESCRIPTION
This is an improvement to the docker compose script made by @mtneug add some explicit declaration and improvements for the database. This PR solves #109 and #110. 

- Database Changes
  - Change of SQL to Opencast 7.x script.
~~- SQL entry point explicit declaration~~
  - Increase of database wait timeout from 600 to 28800

~~- Network Changes~~
~~- Aliases for docker network now with an explicit declaration~~
 ~~- Port 3306 no declared outside to avoid host conflicts.~~

~~Docker Initialization~~
~~- Opencast nodes will wait for ActiveMQ and MariaDB containers to be ready before they start to be deployed.~~


