### PR TITLE
Fix healthcheck script

### DIFF
--- a/Dockerfiles/admin/assets/docker-healthcheck.sh
+++ b/Dockerfiles/admin/assets/docker-healthcheck.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #

--- a/Dockerfiles/adminpresentation/assets/docker-healthcheck.sh
+++ b/Dockerfiles/adminpresentation/assets/docker-healthcheck.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #

--- a/Dockerfiles/adminworker/assets/docker-healthcheck.sh
+++ b/Dockerfiles/adminworker/assets/docker-healthcheck.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #

--- a/Dockerfiles/allinone/assets/docker-healthcheck.sh
+++ b/Dockerfiles/allinone/assets/docker-healthcheck.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #

--- a/Dockerfiles/ingest/assets/docker-healthcheck.sh
+++ b/Dockerfiles/ingest/assets/docker-healthcheck.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #

--- a/Dockerfiles/migration/assets/docker-healthcheck.sh
+++ b/Dockerfiles/migration/assets/docker-healthcheck.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #

--- a/Dockerfiles/presentation/assets/docker-healthcheck.sh
+++ b/Dockerfiles/presentation/assets/docker-healthcheck.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #

--- a/Dockerfiles/worker/assets/docker-healthcheck.sh
+++ b/Dockerfiles/worker/assets/docker-healthcheck.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #


### PR DESCRIPTION
This fixes #112.

`sh` in the base images does not understand the `pipefail` option as was the case with Alpine's shell.