### PR TITLE
Simplify docker-compose examples

### DIFF
--- a/Dockerfiles/build/README.md
+++ b/Dockerfiles/build/README.md
@@ -5,7 +5,6 @@ In order to help you develop Opencast while sill using Docker containers the `qu
 ## Quick Start
 
 ```sh
-$ export HOSTIP=<IP address of the Docker host>
 $ export OPENCAST_SRC=</path/to/my/opencast/code>
 $ export OPENCAST_BUILD_USER_UID=$(id -u)
 $ export OPENCAST_BUILD_USER_GID=$(id -g)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ If you want to build the images yourself, there is a `Makefile` with the necessa
 A quick local test system can be started using [`docker-compose`](https://github.com/docker/compose). After cloning this repository you can run this command from the root directory:
 
 ```sh
-$ export HOSTIP=<IP address of the Docker host>
 $ docker-compose -p opencast-allinone -f docker-compose/docker-compose.allinone.h2.yml up
 ```
 

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -10,9 +10,6 @@ Within this directory you simply can run these commands to startup an Opencast
 system:
 
 ```sh
-# Optional: Set an environment variable with a valid IP address/hostname to the Docker host that should be used for the download URL
-$ export HOSTIP=10.25.40.2
-
 $ docker-compose -f <docker-compose-file>.yml up
 ```
 

--- a/docker-compose/docker-compose.allinone.h2.yml
+++ b/docker-compose/docker-compose.allinone.h2.yml
@@ -33,8 +33,8 @@ services:
   opencast:
     image: quay.io/opencast/allinone:7.4
     environment:
-      - ORG_OPENCASTPROJECT_SERVER_URL=http://opencast:8080
-      - ORG_OPENCASTPROJECT_DOWNLOAD_URL=http://${HOSTIP:-localhost}:8080/static
+      - ORG_OPENCASTPROJECT_SERVER_URL=http://localhost:8080
+      - ORG_OPENCASTPROJECT_DOWNLOAD_URL=http://localhost:8080/static
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER=admin
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS=opencast
       - ORG_OPENCASTPROJECT_SECURITY_DIGEST_USER=opencast_system_account

--- a/docker-compose/docker-compose.allinone.mariadb.yml
+++ b/docker-compose/docker-compose.allinone.mariadb.yml
@@ -46,8 +46,8 @@ services:
   opencast:
     image: quay.io/opencast/allinone:7.4
     environment:
-      - ORG_OPENCASTPROJECT_SERVER_URL=http://opencast:8080
-      - ORG_OPENCASTPROJECT_DOWNLOAD_URL=http://${HOSTIP:-localhost}:8080/static
+      - ORG_OPENCASTPROJECT_SERVER_URL=http://localhost:8080
+      - ORG_OPENCASTPROJECT_DOWNLOAD_URL=http://localhost:8080/static
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER=admin
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS=opencast
       - ORG_OPENCASTPROJECT_SECURITY_DIGEST_USER=opencast_system_account

--- a/docker-compose/docker-compose.build.yml
+++ b/docker-compose/docker-compose.build.yml
@@ -37,8 +37,8 @@ services:
     environment:
       - OPENCAST_BUILD_USER_UID=${OPENCAST_BUILD_USER_UID:-1000}
       - OPENCAST_BUILD_USER_GID=${OPENCAST_BUILD_USER_GID:-1000}
-      - ORG_OPENCASTPROJECT_SERVER_URL=http://opencast:8080
-      - ORG_OPENCASTPROJECT_DOWNLOAD_URL=http://${HOSTIP:-localhost}:8080/static
+      - ORG_OPENCASTPROJECT_SERVER_URL=http://localhost:8080
+      - ORG_OPENCASTPROJECT_DOWNLOAD_URL=http://localhost:8080/static
       - ACTIVEMQ_BROKER_URL=failover://(tcp://activemq:61616)?initialReconnectDelay=2000&maxReconnectDelay=60000
       - ACTIVEMQ_BROKER_USERNAME=admin
       - ACTIVEMQ_BROKER_PASSWORD=password

--- a/docker-compose/docker-compose.multiserver.mariadb.yml
+++ b/docker-compose/docker-compose.multiserver.mariadb.yml
@@ -47,7 +47,7 @@ services:
     image: quay.io/opencast/admin:7.4
     environment:
       - ORG_OPENCASTPROJECT_SERVER_URL=http://opencast-admin:8080
-      - ORG_OPENCASTPROJECT_DOWNLOAD_URL=http://${HOSTIP:-localhost}:8080/static
+      - ORG_OPENCASTPROJECT_DOWNLOAD_URL=http://localhost:8081/static
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER=admin
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS=opencast
       - ORG_OPENCASTPROJECT_SECURITY_DIGEST_USER=opencast_system_account
@@ -56,8 +56,8 @@ services:
       - ORG_OPENCASTPROJECT_DB_JDBC_URL=jdbc:mysql://mariadb/opencast
       - ORG_OPENCASTPROJECT_DB_JDBC_USER=opencast
       - ORG_OPENCASTPROJECT_DB_JDBC_PASS=opencast
-      - PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL=http://opencast-admin:8080
-      - PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL=http://opencast-presentation:8080
+      - PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL=http://localhost:8080
+      - PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL=http://localhost:8081
       - ACTIVEMQ_BROKER_URL=failover://(tcp://activemq:61616)?initialReconnectDelay=2000&maxReconnectDelay=60000
       - ACTIVEMQ_BROKER_USERNAME=admin
       - ACTIVEMQ_BROKER_PASSWORD=password
@@ -70,7 +70,7 @@ services:
     image: quay.io/opencast/presentation:7.4
     environment:
       - ORG_OPENCASTPROJECT_SERVER_URL=http://opencast-presentation:8080
-      - ORG_OPENCASTPROJECT_DOWNLOAD_URL=http://${HOSTIP:-localhost}:8080/static
+      - ORG_OPENCASTPROJECT_DOWNLOAD_URL=http://localhost:8081/static
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER=admin
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS=opencast
       - ORG_OPENCASTPROJECT_SECURITY_DIGEST_USER=opencast_system_account
@@ -79,8 +79,8 @@ services:
       - ORG_OPENCASTPROJECT_DB_JDBC_URL=jdbc:mysql://mariadb/opencast
       - ORG_OPENCASTPROJECT_DB_JDBC_USER=opencast
       - ORG_OPENCASTPROJECT_DB_JDBC_PASS=opencast
-      - PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL=http://opencast-admin:8080
-      - PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL=http://opencast-presentation:8080
+      - PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL=http://localhost:8080
+      - PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL=http://localhost:8081
       - ACTIVEMQ_BROKER_URL=failover://(tcp://activemq:61616)?initialReconnectDelay=2000&maxReconnectDelay=60000
       - ACTIVEMQ_BROKER_USERNAME=admin
       - ACTIVEMQ_BROKER_PASSWORD=password
@@ -93,7 +93,7 @@ services:
     image: quay.io/opencast/worker:7.4
     environment:
       - ORG_OPENCASTPROJECT_SERVER_URL=http://opencast-worker:8080
-      - ORG_OPENCASTPROJECT_DOWNLOAD_URL=http://${HOSTIP:-localhost}:8080/static
+      - ORG_OPENCASTPROJECT_DOWNLOAD_URL=http://localhost:8081/static
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER=admin
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS=opencast
       - ORG_OPENCASTPROJECT_SECURITY_DIGEST_USER=opencast_system_account
@@ -102,8 +102,8 @@ services:
       - ORG_OPENCASTPROJECT_DB_JDBC_URL=jdbc:mysql://mariadb/opencast
       - ORG_OPENCASTPROJECT_DB_JDBC_USER=opencast
       - ORG_OPENCASTPROJECT_DB_JDBC_PASS=opencast
-      - PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL=http://opencast-admin:8080
-      - PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL=http://opencast-presentation:8080
+      - PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL=http://localhost:8080
+      - PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL=http://localhost:8081
       - ACTIVEMQ_BROKER_URL=failover://(tcp://activemq:61616)?initialReconnectDelay=2000&maxReconnectDelay=60000
       - ACTIVEMQ_BROKER_USERNAME=admin
       - ACTIVEMQ_BROKER_PASSWORD=password


### PR DESCRIPTION
Exposed Docker ports are mostly available on localhost on all platforms now. Using localhost also sets the correct URL to the published video.