### PR TITLE
Fix distribution in multiserver example

### DIFF
--- a/docker-compose/docker-compose.multiserver.mariadb.yml
+++ b/docker-compose/docker-compose.multiserver.mariadb.yml
@@ -47,7 +47,7 @@ services:
     image: quay.io/opencast/admin:7.4
     environment:
       - ORG_OPENCASTPROJECT_SERVER_URL=http://opencast-admin:8080
-      - ORG_OPENCASTPROJECT_DOWNLOAD_URL=http://localhost:8081/static
+      - ORG_OPENCASTPROJECT_DOWNLOAD_URL=http://localhost:8080/static
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER=admin
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS=opencast
       - ORG_OPENCASTPROJECT_SECURITY_DIGEST_USER=opencast_system_account
@@ -70,7 +70,7 @@ services:
     image: quay.io/opencast/presentation:7.4
     environment:
       - ORG_OPENCASTPROJECT_SERVER_URL=http://opencast-presentation:8080
-      - ORG_OPENCASTPROJECT_DOWNLOAD_URL=http://localhost:8081/static
+      - ORG_OPENCASTPROJECT_DOWNLOAD_URL=http://localhost:8080/static
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER=admin
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS=opencast
       - ORG_OPENCASTPROJECT_SECURITY_DIGEST_USER=opencast_system_account
@@ -93,7 +93,7 @@ services:
     image: quay.io/opencast/worker:7.4
     environment:
       - ORG_OPENCASTPROJECT_SERVER_URL=http://opencast-worker:8080
-      - ORG_OPENCASTPROJECT_DOWNLOAD_URL=http://localhost:8081/static
+      - ORG_OPENCASTPROJECT_DOWNLOAD_URL=http://localhost:8080/static
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER=admin
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS=opencast
       - ORG_OPENCASTPROJECT_SECURITY_DIGEST_USER=opencast_system_account


### PR DESCRIPTION
The download distribution URL needs to be accessible by all Opencast containers and by the Docker host system. This only applies to localhost:8080, i.e. the admin container. This PR changes the download URL back to this instance.

Note that in the best case you use a normal webserver to serve the content or use the presentation node.

This fixes #122