### PR TITLE
Only Admin node needs Elasticsearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ For an installation with multiple nodes you can also set:
 ## ActiveMQ
 
 -   `ACTIVEMQ_BROKER_URL` **Required**<br>
-    URL to ActiveMQ instances using the format specified in the [Opencast documentation](https://docs.opencast.org/latest/admin/configuration/message-broker/), e.g. `failover://tcp://example.opencast.org:61616`
+    URL to ActiveMQ instances using the format specified in the [Opencast documentation](https://docs.opencast.org/develop/admin/configuration/message-broker.html), e.g. `failover://tcp://example.opencast.org:61616`
 -   `ACTIVEMQ_BROKER_USERNAME` **Required**<br>
     ActiveMQ username.
 -   `ACTIVEMQ_BROKER_PASSWORD` **Required**<br>
@@ -178,6 +178,15 @@ There are no additional environment variables you can set if you are using the H
     Database username.
 -   `ORG_OPENCASTPROJECT_DB_JDBC_PASS` **Required**<br>
     Password of the database user. You may alternatively set `ORG_OPENCASTPROJECT_DB_JDBC_PASS_FILE` to the location of a file within the container that contains the password.
+
+## Elasticsearch
+
+-   `ELASTICSEARCH_SERVER_HOST` **Required for all but `ingest`, `presentation`, `worker`**<br>
+    Host name of the [Elasticsearch](https://docs.opencast.org/develop/admin/configuration/elasticsearch.html) node.
+-   `ELASTICSEARCH_SERVER_SCHEME` Optional<br>
+    The scheme part of the URL to the Elasticsearch node. The default is `http`.
+-   `ELASTICSEARCH_SERVER_PORT` Optional<br>
+    The port on which the Elasticsearch node is reachable. The default is `9200`.
 
 ## Miscellaneous
 

--- a/docker-compose/docker-compose.multiserver.build.yml
+++ b/docker-compose/docker-compose.multiserver.build.yml
@@ -103,7 +103,6 @@ services:
       ACTIVEMQ_BROKER_URL: failover://(tcp://activemq:61616)?initialReconnectDelay=2000&maxReconnectDelay=60000
       ACTIVEMQ_BROKER_USERNAME: admin
       ACTIVEMQ_BROKER_PASSWORD: password
-      ELASTICSEARCH_SERVER_HOST: elasticsearch
     ports:
       - "8081:8080"
       - "5006:5005"
@@ -134,7 +133,6 @@ services:
       ACTIVEMQ_BROKER_URL: failover://(tcp://activemq:61616)?initialReconnectDelay=2000&maxReconnectDelay=60000
       ACTIVEMQ_BROKER_USERNAME: admin
       ACTIVEMQ_BROKER_PASSWORD: password
-      ELASTICSEARCH_SERVER_HOST: elasticsearch
     ports:
       - "8082:8080"
       - "5007:5005"

--- a/docker-compose/docker-compose.multiserver.mariadb.yml
+++ b/docker-compose/docker-compose.multiserver.mariadb.yml
@@ -92,7 +92,6 @@ services:
       ACTIVEMQ_BROKER_URL: failover://(tcp://activemq:61616)?initialReconnectDelay=2000&maxReconnectDelay=60000
       ACTIVEMQ_BROKER_USERNAME: admin
       ACTIVEMQ_BROKER_PASSWORD: password
-      ELASTICSEARCH_SERVER_HOST: elasticsearch
     ports:
       - "8081:8080"
     volumes:
@@ -116,6 +115,5 @@ services:
       ACTIVEMQ_BROKER_URL: failover://(tcp://activemq:61616)?initialReconnectDelay=2000&maxReconnectDelay=60000
       ACTIVEMQ_BROKER_USERNAME: admin
       ACTIVEMQ_BROKER_PASSWORD: password
-      ELASTICSEARCH_SERVER_HOST: elasticsearch
     volumes:
       - data:/data

--- a/docker-compose/docker-compose.multiserver.postgres.yml
+++ b/docker-compose/docker-compose.multiserver.postgres.yml
@@ -90,7 +90,6 @@ services:
       ACTIVEMQ_BROKER_URL: failover://(tcp://activemq:61616)?initialReconnectDelay=2000&maxReconnectDelay=60000
       ACTIVEMQ_BROKER_USERNAME: admin
       ACTIVEMQ_BROKER_PASSWORD: password
-      ELASTICSEARCH_SERVER_HOST: elasticsearch
     ports:
       - "8081:8080"
     volumes:
@@ -114,6 +113,5 @@ services:
       ACTIVEMQ_BROKER_URL: failover://(tcp://activemq:61616)?initialReconnectDelay=2000&maxReconnectDelay=60000
       ACTIVEMQ_BROKER_USERNAME: admin
       ACTIVEMQ_BROKER_PASSWORD: password
-      ELASTICSEARCH_SERVER_HOST: elasticsearch
     volumes:
       - data:/data

--- a/rootfs/opencast/docker/scripts/elasticsearch.sh
+++ b/rootfs/opencast/docker/scripts/elasticsearch.sh
@@ -19,6 +19,12 @@ set -e
 export ELASTICSEARCH_SERVER_SCHEME="${ELASTICSEARCH_SERVER_SCHEME:-http}"
 export ELASTICSEARCH_SERVER_PORT="${ELASTICSEARCH_SERVER_PORT:-9200}"
 
+if opencast_helper_dist_ingest \
+  || opencast_helper_dist_presentation \
+  || opencast_helper_dist_worker; then
+    export ELASTICSEARCH_SERVER_HOST="${ELASTICSEARCH_SERVER_HOST:-localhost}"
+fi
+
 opencast_elasticsearch_check() {
   echo "Run opencast_elasticsearch_check"
 

--- a/rootfs/opencast/docker/scripts/helper.sh
+++ b/rootfs/opencast/docker/scripts/helper.sh
@@ -24,6 +24,18 @@ opencast_helper_dist_develop() {
   test "${OPENCAST_DISTRIBUTION}" = "develop"
 }
 
+opencast_helper_dist_ingest() {
+  test "${OPENCAST_DISTRIBUTION}" = "ingest"
+}
+
+opencast_helper_dist_presentation() {
+  test "${OPENCAST_DISTRIBUTION}" = "presentation"
+}
+
+opencast_helper_dist_worker() {
+  test "${OPENCAST_DISTRIBUTION}" = "worker"
+}
+
 opencast_helper_customconfig() {
   test -d "${OPENCAST_CUSTOM_CONFIG}"
 }


### PR DESCRIPTION
If other nodes need no access, they also do not need to know the Elasticsearch'es host name.

Document Elasticsearch-related environment variables.

https://groups.google.com/a/opencast.org/g/users/c/kMfY5DZEhoU/m/XvENL4dnAgAJ

This PR is untested. When I have time and there is no CI doing this, I will test it, otherwise please feel invited to test this on your side. Thanks for providing these images.