### PR TITLE
Sync custom config changes with running config

### DIFF
--- a/Dockerfiles/admin/Dockerfile
+++ b/Dockerfiles/admin/Dockerfile
@@ -100,9 +100,11 @@ ENV OPENCAST_VERSION="10.0" \
     OPENCAST_GID="800" \
     OPENCAST_REPO="${repo}" \
     OPENCAST_BRANCH="${branch}"
-ENV OPENCAST_SCRIPTS="${OPENCAST_HOME}/docker/scripts" \
+ENV OPENCAST_CONFIG="${OPENCAST_HOME}/etc" \
+    OPENCAST_SCRIPTS="${OPENCAST_HOME}/docker/scripts" \
     OPENCAST_SUPPORT="${OPENCAST_HOME}/docker/support" \
-    OPENCAST_CONFIG="${OPENCAST_HOME}/etc"
+    OPENCAST_STAGE_BASE_HOME="${OPENCAST_HOME}/docker/stage/base" \
+    OPENCAST_STAGE_OUT_HOME="${OPENCAST_HOME}/docker/stage/out"
 
 RUN groupadd --system -g "${OPENCAST_GID}" "${OPENCAST_GROUP}" \
  && useradd --system -M -N -g "${OPENCAST_GROUP}" -d "${OPENCAST_HOME}" -u "${OPENCAST_UID}" "${OPENCAST_USER}" \
@@ -124,10 +126,12 @@ RUN apt-get update \
       hunspell-en-gb \
       hunspell-en-us \
       hunspell-en-za \
+      inotify-tools \
       jq \
       netcat-openbsd \
       nfs-common \
       openssl \
+      rsync \
       sox \
       synfig \
       tesseract-ocr \
@@ -144,7 +148,11 @@ RUN if [ "${OPENCAST_DISTRIBUTION}" = "allinone" ]; then \
       rm -f "${OPENCAST_CONFIG}/org.opencastproject.organization-mh_default_org.cfg-clustered"; \
     fi \
  && mv "${OPENCAST_CONFIG}/org.opencastproject.organization-mh_default_org.cfg-clustered" "${OPENCAST_CONFIG}/org.opencastproject.organization-mh_default_org.cfg" || true \
- && chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_HOME}" \
+ && chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_CONFIG}" \
+  \
+ && mkdir -p "${OPENCAST_STAGE_BASE_HOME}" \
+ && rsync -vrl --chown=0:0 "${OPENCAST_CONFIG}" "${OPENCAST_STAGE_BASE_HOME}" \
+  \
  && javac "${OPENCAST_SCRIPTS}/TryToConnectToDb.java" \
  && rm -rf /tmp/* "${OPENCAST_SCRIPTS}/TryToConnectToDb.java"
 

--- a/Dockerfiles/adminpresentation/Dockerfile
+++ b/Dockerfiles/adminpresentation/Dockerfile
@@ -100,9 +100,11 @@ ENV OPENCAST_VERSION="10.0" \
     OPENCAST_GID="800" \
     OPENCAST_REPO="${repo}" \
     OPENCAST_BRANCH="${branch}"
-ENV OPENCAST_SCRIPTS="${OPENCAST_HOME}/docker/scripts" \
+ENV OPENCAST_CONFIG="${OPENCAST_HOME}/etc" \
+    OPENCAST_SCRIPTS="${OPENCAST_HOME}/docker/scripts" \
     OPENCAST_SUPPORT="${OPENCAST_HOME}/docker/support" \
-    OPENCAST_CONFIG="${OPENCAST_HOME}/etc"
+    OPENCAST_STAGE_BASE_HOME="${OPENCAST_HOME}/docker/stage/base" \
+    OPENCAST_STAGE_OUT_HOME="${OPENCAST_HOME}/docker/stage/out"
 
 RUN groupadd --system -g "${OPENCAST_GID}" "${OPENCAST_GROUP}" \
  && useradd --system -M -N -g "${OPENCAST_GROUP}" -d "${OPENCAST_HOME}" -u "${OPENCAST_UID}" "${OPENCAST_USER}" \
@@ -124,10 +126,12 @@ RUN apt-get update \
       hunspell-en-gb \
       hunspell-en-us \
       hunspell-en-za \
+      inotify-tools \
       jq \
       netcat-openbsd \
       nfs-common \
       openssl \
+      rsync \
       sox \
       synfig \
       tesseract-ocr \
@@ -144,7 +148,11 @@ RUN if [ "${OPENCAST_DISTRIBUTION}" = "allinone" ]; then \
       rm -f "${OPENCAST_CONFIG}/org.opencastproject.organization-mh_default_org.cfg-clustered"; \
     fi \
  && mv "${OPENCAST_CONFIG}/org.opencastproject.organization-mh_default_org.cfg-clustered" "${OPENCAST_CONFIG}/org.opencastproject.organization-mh_default_org.cfg" || true \
- && chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_HOME}" \
+ && chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_CONFIG}" \
+  \
+ && mkdir -p "${OPENCAST_STAGE_BASE_HOME}" \
+ && rsync -vrl --chown=0:0 "${OPENCAST_CONFIG}" "${OPENCAST_STAGE_BASE_HOME}" \
+  \
  && javac "${OPENCAST_SCRIPTS}/TryToConnectToDb.java" \
  && rm -rf /tmp/* "${OPENCAST_SCRIPTS}/TryToConnectToDb.java"
 

--- a/Dockerfiles/allinone/Dockerfile
+++ b/Dockerfiles/allinone/Dockerfile
@@ -100,9 +100,11 @@ ENV OPENCAST_VERSION="10.0" \
     OPENCAST_GID="800" \
     OPENCAST_REPO="${repo}" \
     OPENCAST_BRANCH="${branch}"
-ENV OPENCAST_SCRIPTS="${OPENCAST_HOME}/docker/scripts" \
+ENV OPENCAST_CONFIG="${OPENCAST_HOME}/etc" \
+    OPENCAST_SCRIPTS="${OPENCAST_HOME}/docker/scripts" \
     OPENCAST_SUPPORT="${OPENCAST_HOME}/docker/support" \
-    OPENCAST_CONFIG="${OPENCAST_HOME}/etc"
+    OPENCAST_STAGE_BASE_HOME="${OPENCAST_HOME}/docker/stage/base" \
+    OPENCAST_STAGE_OUT_HOME="${OPENCAST_HOME}/docker/stage/out"
 
 RUN groupadd --system -g "${OPENCAST_GID}" "${OPENCAST_GROUP}" \
  && useradd --system -M -N -g "${OPENCAST_GROUP}" -d "${OPENCAST_HOME}" -u "${OPENCAST_UID}" "${OPENCAST_USER}" \
@@ -124,10 +126,12 @@ RUN apt-get update \
       hunspell-en-gb \
       hunspell-en-us \
       hunspell-en-za \
+      inotify-tools \
       jq \
       netcat-openbsd \
       nfs-common \
       openssl \
+      rsync \
       sox \
       synfig \
       tesseract-ocr \
@@ -144,7 +148,11 @@ RUN if [ "${OPENCAST_DISTRIBUTION}" = "allinone" ]; then \
       rm -f "${OPENCAST_CONFIG}/org.opencastproject.organization-mh_default_org.cfg-clustered"; \
     fi \
  && mv "${OPENCAST_CONFIG}/org.opencastproject.organization-mh_default_org.cfg-clustered" "${OPENCAST_CONFIG}/org.opencastproject.organization-mh_default_org.cfg" || true \
- && chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_HOME}" \
+ && chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_CONFIG}" \
+  \
+ && mkdir -p "${OPENCAST_STAGE_BASE_HOME}" \
+ && rsync -vrl --chown=0:0 "${OPENCAST_CONFIG}" "${OPENCAST_STAGE_BASE_HOME}" \
+  \
  && javac "${OPENCAST_SCRIPTS}/TryToConnectToDb.java" \
  && rm -rf /tmp/* "${OPENCAST_SCRIPTS}/TryToConnectToDb.java"
 

--- a/Dockerfiles/build/Dockerfile
+++ b/Dockerfiles/build/Dockerfile
@@ -43,9 +43,12 @@ ENV ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER="admin" \
     OPENCAST_GID="800" \
     OPENCAST_BUILD_ASSETS="/docker" \
     FFMPEG_VERSION="20210620044626-N-102774-g2cf95f2dd9"
-ENV OPENCAST_SCRIPTS="${OPENCAST_HOME}/docker/scripts" \
+
+ENV OPENCAST_CONFIG="${OPENCAST_HOME}/etc" \
+    OPENCAST_SCRIPTS="${OPENCAST_HOME}/docker/scripts" \
     OPENCAST_SUPPORT="${OPENCAST_HOME}/docker/support" \
-    OPENCAST_CONFIG="${OPENCAST_HOME}/etc" \
+    OPENCAST_STAGE_BASE_HOME="${OPENCAST_HOME}/docker/stage/base" \
+    OPENCAST_STAGE_OUT_HOME="${OPENCAST_HOME}/docker/stage/out" \
     OPENCAST_REPO="${repo}" \
     OPENCAST_BRANCH="${branch}"
 
@@ -78,10 +81,12 @@ RUN apt-get update \
       hunspell-en-gb \
       hunspell-en-us \
       hunspell-en-za \
+      inotify-tools \
       jq \
       netcat-openbsd \
       nfs-common \
       openssl \
+      rsync \
       sox \
       synfig \
       tesseract-ocr \

--- a/Dockerfiles/build/rootfs/usr/local/bin/oc_install
+++ b/Dockerfiles/build/rootfs/usr/local/bin/oc_install
@@ -70,6 +70,8 @@ case "$dist" in
     ;;
 esac
 sudo rm -f "${OPENCAST_CONFIG}/org.ops4j.pax.logging.cfg-develop"
+sudo mkdir -p "${OPENCAST_STAGE_BASE_HOME}"
+sudo rsync -vrl --chown=0:0 "${OPENCAST_CONFIG}" "${OPENCAST_STAGE_BASE_HOME}"
 
 log "oc_install" "Write environment file"
 echo "export OPENCAST_DISTRIBUTION=$dist" | sudo tee "${OPENCAST_SCRIPTS}/env" > /dev/null

--- a/Dockerfiles/ingest/Dockerfile
+++ b/Dockerfiles/ingest/Dockerfile
@@ -100,9 +100,11 @@ ENV OPENCAST_VERSION="10.0" \
     OPENCAST_GID="800" \
     OPENCAST_REPO="${repo}" \
     OPENCAST_BRANCH="${branch}"
-ENV OPENCAST_SCRIPTS="${OPENCAST_HOME}/docker/scripts" \
+ENV OPENCAST_CONFIG="${OPENCAST_HOME}/etc" \
+    OPENCAST_SCRIPTS="${OPENCAST_HOME}/docker/scripts" \
     OPENCAST_SUPPORT="${OPENCAST_HOME}/docker/support" \
-    OPENCAST_CONFIG="${OPENCAST_HOME}/etc"
+    OPENCAST_STAGE_BASE_HOME="${OPENCAST_HOME}/docker/stage/base" \
+    OPENCAST_STAGE_OUT_HOME="${OPENCAST_HOME}/docker/stage/out"
 
 RUN groupadd --system -g "${OPENCAST_GID}" "${OPENCAST_GROUP}" \
  && useradd --system -M -N -g "${OPENCAST_GROUP}" -d "${OPENCAST_HOME}" -u "${OPENCAST_UID}" "${OPENCAST_USER}" \
@@ -124,10 +126,12 @@ RUN apt-get update \
       hunspell-en-gb \
       hunspell-en-us \
       hunspell-en-za \
+      inotify-tools \
       jq \
       netcat-openbsd \
       nfs-common \
       openssl \
+      rsync \
       sox \
       synfig \
       tesseract-ocr \
@@ -144,7 +148,11 @@ RUN if [ "${OPENCAST_DISTRIBUTION}" = "allinone" ]; then \
       rm -f "${OPENCAST_CONFIG}/org.opencastproject.organization-mh_default_org.cfg-clustered"; \
     fi \
  && mv "${OPENCAST_CONFIG}/org.opencastproject.organization-mh_default_org.cfg-clustered" "${OPENCAST_CONFIG}/org.opencastproject.organization-mh_default_org.cfg" || true \
- && chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_HOME}" \
+ && chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_CONFIG}" \
+  \
+ && mkdir -p "${OPENCAST_STAGE_BASE_HOME}" \
+ && rsync -vrl --chown=0:0 "${OPENCAST_CONFIG}" "${OPENCAST_STAGE_BASE_HOME}" \
+  \
  && javac "${OPENCAST_SCRIPTS}/TryToConnectToDb.java" \
  && rm -rf /tmp/* "${OPENCAST_SCRIPTS}/TryToConnectToDb.java"
 

--- a/Dockerfiles/presentation/Dockerfile
+++ b/Dockerfiles/presentation/Dockerfile
@@ -100,9 +100,11 @@ ENV OPENCAST_VERSION="10.0" \
     OPENCAST_GID="800" \
     OPENCAST_REPO="${repo}" \
     OPENCAST_BRANCH="${branch}"
-ENV OPENCAST_SCRIPTS="${OPENCAST_HOME}/docker/scripts" \
+ENV OPENCAST_CONFIG="${OPENCAST_HOME}/etc" \
+    OPENCAST_SCRIPTS="${OPENCAST_HOME}/docker/scripts" \
     OPENCAST_SUPPORT="${OPENCAST_HOME}/docker/support" \
-    OPENCAST_CONFIG="${OPENCAST_HOME}/etc"
+    OPENCAST_STAGE_BASE_HOME="${OPENCAST_HOME}/docker/stage/base" \
+    OPENCAST_STAGE_OUT_HOME="${OPENCAST_HOME}/docker/stage/out"
 
 RUN groupadd --system -g "${OPENCAST_GID}" "${OPENCAST_GROUP}" \
  && useradd --system -M -N -g "${OPENCAST_GROUP}" -d "${OPENCAST_HOME}" -u "${OPENCAST_UID}" "${OPENCAST_USER}" \
@@ -124,10 +126,12 @@ RUN apt-get update \
       hunspell-en-gb \
       hunspell-en-us \
       hunspell-en-za \
+      inotify-tools \
       jq \
       netcat-openbsd \
       nfs-common \
       openssl \
+      rsync \
       sox \
       synfig \
       tesseract-ocr \
@@ -144,7 +148,11 @@ RUN if [ "${OPENCAST_DISTRIBUTION}" = "allinone" ]; then \
       rm -f "${OPENCAST_CONFIG}/org.opencastproject.organization-mh_default_org.cfg-clustered"; \
     fi \
  && mv "${OPENCAST_CONFIG}/org.opencastproject.organization-mh_default_org.cfg-clustered" "${OPENCAST_CONFIG}/org.opencastproject.organization-mh_default_org.cfg" || true \
- && chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_HOME}" \
+ && chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_CONFIG}" \
+  \
+ && mkdir -p "${OPENCAST_STAGE_BASE_HOME}" \
+ && rsync -vrl --chown=0:0 "${OPENCAST_CONFIG}" "${OPENCAST_STAGE_BASE_HOME}" \
+  \
  && javac "${OPENCAST_SCRIPTS}/TryToConnectToDb.java" \
  && rm -rf /tmp/* "${OPENCAST_SCRIPTS}/TryToConnectToDb.java"
 

--- a/Dockerfiles/worker/Dockerfile
+++ b/Dockerfiles/worker/Dockerfile
@@ -100,9 +100,11 @@ ENV OPENCAST_VERSION="10.0" \
     OPENCAST_GID="800" \
     OPENCAST_REPO="${repo}" \
     OPENCAST_BRANCH="${branch}"
-ENV OPENCAST_SCRIPTS="${OPENCAST_HOME}/docker/scripts" \
+ENV OPENCAST_CONFIG="${OPENCAST_HOME}/etc" \
+    OPENCAST_SCRIPTS="${OPENCAST_HOME}/docker/scripts" \
     OPENCAST_SUPPORT="${OPENCAST_HOME}/docker/support" \
-    OPENCAST_CONFIG="${OPENCAST_HOME}/etc"
+    OPENCAST_STAGE_BASE_HOME="${OPENCAST_HOME}/docker/stage/base" \
+    OPENCAST_STAGE_OUT_HOME="${OPENCAST_HOME}/docker/stage/out"
 
 RUN groupadd --system -g "${OPENCAST_GID}" "${OPENCAST_GROUP}" \
  && useradd --system -M -N -g "${OPENCAST_GROUP}" -d "${OPENCAST_HOME}" -u "${OPENCAST_UID}" "${OPENCAST_USER}" \
@@ -124,10 +126,12 @@ RUN apt-get update \
       hunspell-en-gb \
       hunspell-en-us \
       hunspell-en-za \
+      inotify-tools \
       jq \
       netcat-openbsd \
       nfs-common \
       openssl \
+      rsync \
       sox \
       synfig \
       tesseract-ocr \
@@ -144,7 +148,11 @@ RUN if [ "${OPENCAST_DISTRIBUTION}" = "allinone" ]; then \
       rm -f "${OPENCAST_CONFIG}/org.opencastproject.organization-mh_default_org.cfg-clustered"; \
     fi \
  && mv "${OPENCAST_CONFIG}/org.opencastproject.organization-mh_default_org.cfg-clustered" "${OPENCAST_CONFIG}/org.opencastproject.organization-mh_default_org.cfg" || true \
- && chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_HOME}" \
+ && chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_CONFIG}" \
+  \
+ && mkdir -p "${OPENCAST_STAGE_BASE_HOME}" \
+ && rsync -vrl --chown=0:0 "${OPENCAST_CONFIG}" "${OPENCAST_STAGE_BASE_HOME}" \
+  \
  && javac "${OPENCAST_SCRIPTS}/TryToConnectToDb.java" \
  && rm -rf /tmp/* "${OPENCAST_SCRIPTS}/TryToConnectToDb.java"
 

--- a/rootfs/opencast/docker/scripts/activemq.sh
+++ b/rootfs/opencast/docker/scripts/activemq.sh
@@ -28,7 +28,7 @@ opencast_activemq_check() {
 opencast_activemq_configure() {
   echo "Run opencast_activemq_configure"
 
-  opencast_helper_replaceinfile "etc/custom.properties" \
+  opencast_helper_replaceinfile "${OPENCAST_HOME}/etc/custom.properties" \
     "ACTIVEMQ_BROKER_URL" \
     "ACTIVEMQ_BROKER_USERNAME" \
     "ACTIVEMQ_BROKER_PASSWORD"

--- a/rootfs/opencast/docker/scripts/elasticsearch.sh
+++ b/rootfs/opencast/docker/scripts/elasticsearch.sh
@@ -31,7 +31,7 @@ opencast_elasticsearch_check() {
 opencast_elasticsearch_configure() {
   echo "Run opencast_elasticsearch_configure"
 
-  opencast_helper_replaceinfile "etc/custom.properties" \
+  opencast_helper_replaceinfile "${OPENCAST_HOME}/etc/custom.properties" \
     "ELASTICSEARCH_SERVER_HOST" \
     "ELASTICSEARCH_SERVER_SCHEME" \
     "ELASTICSEARCH_SERVER_PORT"

--- a/rootfs/opencast/docker/scripts/h2.sh
+++ b/rootfs/opencast/docker/scripts/h2.sh
@@ -23,7 +23,7 @@ opencast_h2_check() {
 opencast_h2_configure() {
   echo "Run opencast_h2_configure"
 
-  opencast_helper_deleteinfile "etc/custom.properties" \
+  opencast_helper_deleteinfile "${OPENCAST_HOME}/etc/custom.properties" \
     "ORG_OPENCASTPROJECT_DB_JDBC_DRIVER" \
     "ORG_OPENCASTPROJECT_DB_JDBC_URL" \
     "ORG_OPENCASTPROJECT_DB_JDBC_USER" \

--- a/rootfs/opencast/docker/scripts/helper.sh
+++ b/rootfs/opencast/docker/scripts/helper.sh
@@ -28,9 +28,25 @@ opencast_helper_customconfig() {
   test -d "${OPENCAST_CUSTOM_CONFIG}"
 }
 
-opencast_helper_copycustomconfig() {
-  cp -RL "${OPENCAST_CUSTOM_CONFIG}"/* "${OPENCAST_CONFIG}"
-  chown -R "${OPENCAST_USER}:${OPENCAST_GROUP}" "${OPENCAST_CONFIG}"
+opencast_helper_customconfig_wait_for_change() {
+  inotifywait -q -r -e modify,attrib,close_write,create,move,delete "${OPENCAST_CUSTOM_CONFIG}"
+
+  # One change seldom comes alone. Wait for good measure.
+  sleep 2
+}
+
+opencast_helper_stage_base() {
+  rsync -qcrl --chown=0:0 "${OPENCAST_STAGE_BASE_HOME}/" "${OPENCAST_STAGE_OUT_HOME}"
+}
+
+opencast_helper_stage_customconfig() {
+  # Kubernetes will create symlinked files to folders to change out mounted configuration simultaneously. The folder
+  # names start with two dots. Let's ignore them and dereference the symbolic links.
+  rsync -qcrLK --chown=0:0 --exclude="..*" "${OPENCAST_CUSTOM_CONFIG}/" "${OPENCAST_STAGE_OUT_HOME}/etc"
+}
+
+opencast_helper_deploy_staged_config() {
+  rsync -qcrl --chown="${OPENCAST_UID}:${OPENCAST_GID}" --delete "${OPENCAST_STAGE_OUT_HOME}/etc/" "${OPENCAST_CONFIG}"
 }
 
 opencast_helper_checkforvariables() {

--- a/rootfs/opencast/docker/scripts/helper.sh
+++ b/rootfs/opencast/docker/scripts/helper.sh
@@ -29,7 +29,7 @@ opencast_helper_customconfig() {
 }
 
 opencast_helper_customconfig_wait_for_change() {
-  inotifywait -q -r -e modify,attrib,close_write,create,move,delete "${OPENCAST_CUSTOM_CONFIG}"
+  inotifywait -q -r -e modify,close_write,create,move,delete "${OPENCAST_CUSTOM_CONFIG}"
 
   # One change seldom comes alone. Wait for good measure.
   sleep 2

--- a/rootfs/opencast/docker/scripts/jdbc.sh
+++ b/rootfs/opencast/docker/scripts/jdbc.sh
@@ -29,7 +29,7 @@ opencast_jdbc_check() {
 opencast_jdbc_configure() {
   echo "Run opencast_jdbc_configure"
 
-  opencast_helper_replaceinfile "etc/custom.properties" \
+  opencast_helper_replaceinfile "${OPENCAST_HOME}/etc/custom.properties" \
     "ORG_OPENCASTPROJECT_DB_JDBC_DRIVER" \
     "ORG_OPENCASTPROJECT_DB_JDBC_URL" \
     "ORG_OPENCASTPROJECT_DB_JDBC_USER" \
@@ -39,10 +39,10 @@ opencast_jdbc_configure() {
 opencast_jdbc_trytoconnect() {
   echo "Run opencast_jdbc_trytoconnect"
 
-  driver=$(grep "^org.opencastproject.db.jdbc.driver" etc/custom.properties | tr -d ' ' | cut -d '=' -f 2-)
-  url=$(grep "^org.opencastproject.db.jdbc.url" etc/custom.properties | tr -d ' ' | cut -d '=' -f 2-)
-  user=$(grep "^org.opencastproject.db.jdbc.user" etc/custom.properties | tr -d ' ' | cut -d '=' -f 2-)
-  password=$(grep "^org.opencastproject.db.jdbc.pass" etc/custom.properties | tr -d ' ' | cut -d '=' -f 2-)
+  driver=$(grep "^org.opencastproject.db.jdbc.driver" "${OPENCAST_HOME}/etc/custom.properties" | tr -d ' ' | cut -d '=' -f 2-)
+  url=$(grep "^org.opencastproject.db.jdbc.url" "${OPENCAST_HOME}/etc/custom.properties" | tr -d ' ' | cut -d '=' -f 2-)
+  user=$(grep "^org.opencastproject.db.jdbc.user" "${OPENCAST_HOME}/etc/custom.properties" | tr -d ' ' | cut -d '=' -f 2-)
+  password=$(grep "^org.opencastproject.db.jdbc.pass" "${OPENCAST_HOME}/etc/custom.properties" | tr -d ' ' | cut -d '=' -f 2-)
   db_jar=$(find "${OPENCAST_HOME}/system/org/opencastproject" -name 'opencast-db-*.jar')
 
   java -cp "${OPENCAST_SCRIPTS}:${db_jar}" \

--- a/rootfs/opencast/docker/scripts/opencast.sh
+++ b/rootfs/opencast/docker/scripts/opencast.sh
@@ -46,7 +46,7 @@ opencast_opencast_check() {
 
 opencast_opencast_configure() {
   echo "Run opencast_opencast_configure"
-  opencast_helper_replaceinfile "etc/custom.properties" \
+  opencast_helper_replaceinfile "${OPENCAST_HOME}/etc/custom.properties" \
     "ORG_OPENCASTPROJECT_ADMIN_EMAIL" \
     "ORG_OPENCASTPROJECT_SERVER_URL" \
     "ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER" \
@@ -55,7 +55,7 @@ opencast_opencast_configure() {
     "ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS" \
     "ORG_OPENCASTPROJECT_DOWNLOAD_URL"
 
-  opencast_helper_replaceinfile "etc/org.opencastproject.organization-mh_default_org.cfg" \
+  opencast_helper_replaceinfile "${OPENCAST_HOME}/etc/org.opencastproject.organization-mh_default_org.cfg" \
     "PROP_ORG_OPENCASTPROJECT_FILE_REPO_URL" \
     "PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL" \
     "PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL"


### PR DESCRIPTION
Currently, custom config mounted to `/etc/opencast` is not synced with the running config `/opencast/etc` on changes. This adds a watch background job that syncs those files. `/etc/opencast` is implemented as an overlay over the default Opencast configuration. Those are first merged in a staging area then variables may be replaced after which the files are synced to `/opencast/etc`. Using `rsync` anly necessary copy and delete operations are performed such that Opencast service reconfiguration should be kept to a minimum.

This also ignores folders/symlinks in the custom config that starts with two dots. This is used by Kubernetes when mounting configuration and secrets.