### PR TITLE
Add Elasticsearch Log4Shell Mitigation

### DIFF
--- a/docker-compose/docker-compose.allinone.h2+pyca.yml
+++ b/docker-compose/docker-compose.allinone.h2+pyca.yml
@@ -36,6 +36,7 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
     environment:
       discovery.type: single-node
+      ES_JAVA_OPTS: '-Dlog4j2.formatMsgNoLookups=true'
     volumes:
       - elastic:/usr/share/elasticsearch/data
 

--- a/docker-compose/docker-compose.allinone.h2.yml
+++ b/docker-compose/docker-compose.allinone.h2.yml
@@ -35,6 +35,7 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
     environment:
       discovery.type: single-node
+      ES_JAVA_OPTS: '-Dlog4j2.formatMsgNoLookups=true'
     volumes:
       - elastic:/usr/share/elasticsearch/data
 

--- a/docker-compose/docker-compose.allinone.mariadb.yml
+++ b/docker-compose/docker-compose.allinone.mariadb.yml
@@ -47,6 +47,7 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
     environment:
       discovery.type: single-node
+      ES_JAVA_OPTS: '-Dlog4j2.formatMsgNoLookups=true'
     volumes:
       - elastic:/usr/share/elasticsearch/data
 

--- a/docker-compose/docker-compose.allinone.postgres.yml
+++ b/docker-compose/docker-compose.allinone.postgres.yml
@@ -45,6 +45,7 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
     environment:
       discovery.type: single-node
+      ES_JAVA_OPTS: '-Dlog4j2.formatMsgNoLookups=true'
     volumes:
       - elastic:/usr/share/elasticsearch/data
 

--- a/docker-compose/docker-compose.build.yml
+++ b/docker-compose/docker-compose.build.yml
@@ -35,6 +35,7 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
     environment:
       discovery.type: single-node
+      ES_JAVA_OPTS: '-Dlog4j2.formatMsgNoLookups=true'
     volumes:
       - elastic:/usr/share/elasticsearch/data
 

--- a/docker-compose/docker-compose.multiserver.build.yml
+++ b/docker-compose/docker-compose.multiserver.build.yml
@@ -47,6 +47,7 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
     environment:
       discovery.type: single-node
+      ES_JAVA_OPTS: '-Dlog4j2.formatMsgNoLookups=true'
     volumes:
       - elastic:/usr/share/elasticsearch/data
 

--- a/docker-compose/docker-compose.multiserver.mariadb.yml
+++ b/docker-compose/docker-compose.multiserver.mariadb.yml
@@ -47,6 +47,7 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
     environment:
       discovery.type: single-node
+      ES_JAVA_OPTS: '-Dlog4j2.formatMsgNoLookups=true'
     volumes:
       - elastic:/usr/share/elasticsearch/data
 

--- a/docker-compose/docker-compose.multiserver.postgres.yml
+++ b/docker-compose/docker-compose.multiserver.postgres.yml
@@ -45,6 +45,7 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
     environment:
       discovery.type: single-node
+      ES_JAVA_OPTS: '-Dlog4j2.formatMsgNoLookups=true'
     volumes:
       - elastic:/usr/share/elasticsearch/data
 


### PR DESCRIPTION
This patch adds the mitigation for CVE-2021-44228 to the default
Elasticsearch configuration in the docker-compose files.