### PR TITLE
Switch to using OpenSearch

### DIFF
--- a/docker-compose/docker-compose.allinone.h2+pyca.yml
+++ b/docker-compose/docker-compose.allinone.h2+pyca.yml
@@ -15,18 +15,21 @@
 version: "3"
 
 volumes:
-  elastic: {}
+  opensearch: {}
   data: {}
   pyca: {}
 
 services:
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+  opensearch:
+    image: opensearchproject/opensearch:1
     environment:
       discovery.type: single-node
-      ES_JAVA_OPTS: '-Dlog4j2.formatMsgNoLookups=true'
+      bootstrap.memory_lock: true
+      OPENSEARCH_JAVA_OPTS: -Xms128m -Xmx512m
+      DISABLE_INSTALL_DEMO_CONFIG: true
+      DISABLE_SECURITY_PLUGIN: true
     volumes:
-      - elastic:/usr/share/elasticsearch/data
+      - opensearch:/usr/share/opensearch/data
 
   opencast:
     image: quay.io/opencast/allinone:12.0
@@ -37,7 +40,7 @@ services:
       ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS: opencast
       ORG_OPENCASTPROJECT_SECURITY_DIGEST_USER: opencast_system_account
       ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS: CHANGE_ME
-      ELASTICSEARCH_SERVER_HOST: elasticsearch
+      ELASTICSEARCH_SERVER_HOST: opensearch
     ports:
       - "8080:8080"
     volumes:

--- a/docker-compose/docker-compose.allinone.h2.yml
+++ b/docker-compose/docker-compose.allinone.h2.yml
@@ -15,17 +15,20 @@
 version: "3"
 
 volumes:
-  elastic: {}
+  opensearch: {}
   data: {}
 
 services:
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+  opensearch:
+    image: opensearchproject/opensearch:1
     environment:
       discovery.type: single-node
-      ES_JAVA_OPTS: '-Dlog4j2.formatMsgNoLookups=true'
+      bootstrap.memory_lock: true
+      OPENSEARCH_JAVA_OPTS: -Xms128m -Xmx512m
+      DISABLE_INSTALL_DEMO_CONFIG: true
+      DISABLE_SECURITY_PLUGIN: true
     volumes:
-      - elastic:/usr/share/elasticsearch/data
+      - opensearch:/usr/share/opensearch/data
 
   opencast:
     image: quay.io/opencast/allinone:12.0
@@ -36,7 +39,7 @@ services:
       ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS: opencast
       ORG_OPENCASTPROJECT_SECURITY_DIGEST_USER: opencast_system_account
       ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS: CHANGE_ME
-      ELASTICSEARCH_SERVER_HOST: elasticsearch
+      ELASTICSEARCH_SERVER_HOST: opensearch
     ports:
       - "8080:8080"
     volumes:

--- a/docker-compose/docker-compose.allinone.mariadb.yml
+++ b/docker-compose/docker-compose.allinone.mariadb.yml
@@ -16,7 +16,7 @@ version: "3"
 
 volumes:
   db: {}
-  elastic: {}
+  opensearch: {}
   data: {}
 
 services:
@@ -31,13 +31,16 @@ services:
     volumes:
       - db:/var/lib/mysql
 
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+  opensearch:
+    image: opensearchproject/opensearch:1
     environment:
       discovery.type: single-node
-      ES_JAVA_OPTS: '-Dlog4j2.formatMsgNoLookups=true'
+      bootstrap.memory_lock: true
+      OPENSEARCH_JAVA_OPTS: -Xms128m -Xmx512m
+      DISABLE_INSTALL_DEMO_CONFIG: true
+      DISABLE_SECURITY_PLUGIN: true
     volumes:
-      - elastic:/usr/share/elasticsearch/data
+      - opensearch:/usr/share/opensearch/data
 
   opencast:
     image: quay.io/opencast/allinone:12.0
@@ -52,7 +55,7 @@ services:
       ORG_OPENCASTPROJECT_DB_JDBC_URL: jdbc:mariadb://mariadb/opencast?useMysqlMetadata=true
       ORG_OPENCASTPROJECT_DB_JDBC_USER: opencast
       ORG_OPENCASTPROJECT_DB_JDBC_PASS: opencast
-      ELASTICSEARCH_SERVER_HOST: elasticsearch
+      ELASTICSEARCH_SERVER_HOST: opensearch
     ports:
       - "8080:8080"
     volumes:

--- a/docker-compose/docker-compose.allinone.postgres.yml
+++ b/docker-compose/docker-compose.allinone.postgres.yml
@@ -16,7 +16,7 @@ version: "3"
 
 volumes:
   db: {}
-  elastic: {}
+  opensearch: {}
   data: {}
 
 services:
@@ -29,13 +29,16 @@ services:
     volumes:
       - db:/var/lib/postgresql/data
 
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+  opensearch:
+    image: opensearchproject/opensearch:1
     environment:
       discovery.type: single-node
-      ES_JAVA_OPTS: '-Dlog4j2.formatMsgNoLookups=true'
+      bootstrap.memory_lock: true
+      OPENSEARCH_JAVA_OPTS: -Xms128m -Xmx512m
+      DISABLE_INSTALL_DEMO_CONFIG: true
+      DISABLE_SECURITY_PLUGIN: true
     volumes:
-      - elastic:/usr/share/elasticsearch/data
+      - opensearch:/usr/share/opensearch/data
 
   opencast:
     image: quay.io/opencast/allinone:12.0
@@ -50,7 +53,7 @@ services:
       ORG_OPENCASTPROJECT_DB_JDBC_URL: jdbc:postgresql://postgresql/opencast
       ORG_OPENCASTPROJECT_DB_JDBC_USER: opencast
       ORG_OPENCASTPROJECT_DB_JDBC_PASS: opencast
-      ELASTICSEARCH_SERVER_HOST: elasticsearch
+      ELASTICSEARCH_SERVER_HOST: opensearch
     ports:
       - "8080:8080"
     volumes:

--- a/docker-compose/docker-compose.build.yml
+++ b/docker-compose/docker-compose.build.yml
@@ -15,17 +15,20 @@
 version: "3"
 
 volumes:
-  elastic: {}
+  opensearch: {}
   data: {}
 
 services:
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+  opensearch:
+    image: opensearchproject/opensearch:1
     environment:
       discovery.type: single-node
-      ES_JAVA_OPTS: '-Dlog4j2.formatMsgNoLookups=true'
+      bootstrap.memory_lock: true
+      OPENSEARCH_JAVA_OPTS: -Xms128m -Xmx512m
+      DISABLE_INSTALL_DEMO_CONFIG: true
+      DISABLE_SECURITY_PLUGIN: true
     volumes:
-      - elastic:/usr/share/elasticsearch/data
+      - opensearch:/usr/share/opensearch/data
 
   opencast:
     image: quay.io/opencast/build:12.0
@@ -36,7 +39,7 @@ services:
       OPENCAST_BUILD_USER_GID: ${OPENCAST_BUILD_USER_GID:-1000}
       ORG_OPENCASTPROJECT_SERVER_URL: http://localhost:8080
       ORG_OPENCASTPROJECT_DOWNLOAD_URL: http://localhost:8080/static
-      ELASTICSEARCH_SERVER_HOST: elasticsearch
+      ELASTICSEARCH_SERVER_HOST: opensearch
     ports:
       - "8080:8080"
       - "5005:5005"

--- a/docker-compose/docker-compose.multiserver.build.yml
+++ b/docker-compose/docker-compose.multiserver.build.yml
@@ -16,7 +16,7 @@ version: "3"
 
 volumes:
   db: {}
-  elastic: {}
+  opensearch: {}
   data: {}
 
 services:
@@ -31,13 +31,16 @@ services:
     volumes:
       - db:/var/lib/mysql
 
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+  opensearch:
+    image: opensearchproject/opensearch:1
     environment:
       discovery.type: single-node
-      ES_JAVA_OPTS: '-Dlog4j2.formatMsgNoLookups=true'
+      bootstrap.memory_lock: true
+      OPENSEARCH_JAVA_OPTS: -Xms128m -Xmx512m
+      DISABLE_INSTALL_DEMO_CONFIG: true
+      DISABLE_SECURITY_PLUGIN: true
     volumes:
-      - elastic:/usr/share/elasticsearch/data
+      - opensearch:/usr/share/opensearch/data
 
   opencast-admin:
     image: quay.io/opencast/build:12.0
@@ -58,7 +61,7 @@ services:
       ORG_OPENCASTPROJECT_DB_JDBC_PASS: opencast
       PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL: http://localhost:8080
       PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL: http://localhost:8081
-      ELASTICSEARCH_SERVER_HOST: elasticsearch
+      ELASTICSEARCH_SERVER_HOST: opensearch
     ports:
       - "8080:8080"
       - "5005:5005"
@@ -86,7 +89,7 @@ services:
       ORG_OPENCASTPROJECT_DB_JDBC_PASS: opencast
       PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL: http://localhost:8080
       PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL: http://localhost:8081
-      ELASTICSEARCH_SERVER_HOST: elasticsearch
+      ELASTICSEARCH_SERVER_HOST: opensearch
     ports:
       - "8081:8080"
       - "5006:5005"
@@ -114,7 +117,7 @@ services:
       ORG_OPENCASTPROJECT_DB_JDBC_PASS: opencast
       PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL: http://localhost:8080
       PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL: http://localhost:8081
-      ELASTICSEARCH_SERVER_HOST: elasticsearch
+      ELASTICSEARCH_SERVER_HOST: opensearch
     ports:
       - "8082:8080"
       - "5007:5005"

--- a/docker-compose/docker-compose.multiserver.mariadb.yml
+++ b/docker-compose/docker-compose.multiserver.mariadb.yml
@@ -16,7 +16,7 @@ version: "3"
 
 volumes:
   db: {}
-  elastic: {}
+  opensearch: {}
   data: {}
 
 services:
@@ -31,13 +31,16 @@ services:
     volumes:
       - db:/var/lib/mysql
 
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+  opensearch:
+    image: opensearchproject/opensearch:1
     environment:
       discovery.type: single-node
-      ES_JAVA_OPTS: '-Dlog4j2.formatMsgNoLookups=true'
+      bootstrap.memory_lock: true
+      OPENSEARCH_JAVA_OPTS: -Xms128m -Xmx512m
+      DISABLE_INSTALL_DEMO_CONFIG: true
+      DISABLE_SECURITY_PLUGIN: true
     volumes:
-      - elastic:/usr/share/elasticsearch/data
+      - opensearch:/usr/share/opensearch/data
 
   opencast-admin:
     image: quay.io/opencast/admin:12.0
@@ -54,7 +57,7 @@ services:
       ORG_OPENCASTPROJECT_DB_JDBC_PASS: opencast
       PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL: http://localhost:8080
       PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL: http://localhost:8081
-      ELASTICSEARCH_SERVER_HOST: elasticsearch
+      ELASTICSEARCH_SERVER_HOST: opensearch
     ports:
       - "8080:8080"
     volumes:
@@ -75,7 +78,7 @@ services:
       ORG_OPENCASTPROJECT_DB_JDBC_PASS: opencast
       PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL: http://localhost:8080
       PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL: http://localhost:8081
-      ELASTICSEARCH_SERVER_HOST: elasticsearch
+      ELASTICSEARCH_SERVER_HOST: opensearch
     ports:
       - "8081:8080"
     volumes:
@@ -96,6 +99,6 @@ services:
       ORG_OPENCASTPROJECT_DB_JDBC_PASS: opencast
       PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL: http://localhost:8080
       PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL: http://localhost:8081
-      ELASTICSEARCH_SERVER_HOST: elasticsearch
+      ELASTICSEARCH_SERVER_HOST: opensearch
     volumes:
       - data:/data

--- a/docker-compose/docker-compose.multiserver.postgres.yml
+++ b/docker-compose/docker-compose.multiserver.postgres.yml
@@ -16,7 +16,7 @@ version: "3"
 
 volumes:
   db: {}
-  elastic: {}
+  opensearch: {}
   data: {}
 
 services:
@@ -29,13 +29,16 @@ services:
     volumes:
       - db:/var/lib/postgresql/data
 
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+  opensearch:
+    image: opensearchproject/opensearch:1
     environment:
       discovery.type: single-node
-      ES_JAVA_OPTS: '-Dlog4j2.formatMsgNoLookups=true'
+      bootstrap.memory_lock: true
+      OPENSEARCH_JAVA_OPTS: -Xms128m -Xmx512m
+      DISABLE_INSTALL_DEMO_CONFIG: true
+      DISABLE_SECURITY_PLUGIN: true
     volumes:
-      - elastic:/usr/share/elasticsearch/data
+      - opensearch:/usr/share/opensearch/data
 
   opencast-admin:
     image: quay.io/opencast/admin:12.0
@@ -52,7 +55,7 @@ services:
       ORG_OPENCASTPROJECT_DB_JDBC_PASS: opencast
       PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL: http://localhost:8080
       PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL: http://localhost:8081
-      ELASTICSEARCH_SERVER_HOST: elasticsearch
+      ELASTICSEARCH_SERVER_HOST: opensearch
     ports:
       - "8080:8080"
     volumes:
@@ -73,7 +76,7 @@ services:
       ORG_OPENCASTPROJECT_DB_JDBC_PASS: opencast
       PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL: http://localhost:8080
       PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL: http://localhost:8081
-      ELASTICSEARCH_SERVER_HOST: elasticsearch
+      ELASTICSEARCH_SERVER_HOST: opensearch
     ports:
       - "8081:8080"
     volumes:
@@ -94,6 +97,6 @@ services:
       ORG_OPENCASTPROJECT_DB_JDBC_PASS: opencast
       PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL: http://localhost:8080
       PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL: http://localhost:8081
-      ELASTICSEARCH_SERVER_HOST: elasticsearch
+      ELASTICSEARCH_SERVER_HOST: opensearch
     volumes:
       - data:/data


### PR DESCRIPTION
Opencast switched to OpenSearch examples in the dev container setup. OpenSearch v1 is compatible with Elasticsearch.