### PR TITLE
Update packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,6 @@ RUN apt-get update \
       inotify-tools \
       jq \
       netcat-openbsd \
-      nfs-common \
       openssl \
       rsync \
       sox \

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,8 @@ RUN apt-get update \
       fontconfig \
       fonts-dejavu \
       fonts-freefont-ttf \
+      python3 \
+      python3-pip \
       fonts-liberation \
       fonts-linuxlibertine \
       hunspell \
@@ -120,6 +122,8 @@ RUN apt-get update \
       tesseract-ocr \
       tesseract-ocr-eng \
       tzdata \
+ && pip install \
+      vosk-cli \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /usr/local/sbin/su-exec /usr/local/sbin/

--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -89,7 +89,6 @@ RUN apt-get update \
       inotify-tools \
       jq \
       netcat-openbsd \
-      nfs-common \
       openssl \
       rsync \
       sox \

--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -90,12 +90,16 @@ RUN apt-get update \
       jq \
       netcat-openbsd \
       openssl \
+      python3 \
+      python3-pip \
       rsync \
       sox \
       synfig \
       tesseract-ocr \
       tesseract-ocr-eng \
       tzdata \
+ && pip install \
+      vosk-cli \
   \
  && sudo ln -s /usr/local/openjdk*/bin/* /usr/local/bin/ \
   \


### PR DESCRIPTION
This updates installed packages:

1. Removes `nfs-common` from within the container. Mounts are usually created outside of the container runtime.
2. Add vosk support through the vosk-cli.